### PR TITLE
Fix: fix 16k page size issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 19
+        versionCode 20
         versionName "1.3.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 18
+        versionCode 19
         versionName "1.3.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 34
+    compileSdk 35
     buildFeatures {
         viewBinding true
     }
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 18
         versionName "1.3.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,17 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# ---- Room ----
+# Keep all Room-generated _Impl classes and their constructors.
+# R8 strips these by default since they are only referenced via reflection.
+-keep class **.*_Impl { *; }
+-keep class **.*_Impl$* { *; }
+
+# Keep Room database subclasses
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keepclassmembers class * extends androidx.room.RoomDatabase { *; }
+
+# Keep Room entity and DAO annotations so R8 doesn't rename them
+-keep @androidx.room.Entity class * { *; }
+-keep @androidx.room.Dao interface * { *; }


### PR DESCRIPTION
Root cause: Room generates CounterDatabase_Impl at compile time, but references it only via reflection (Room.getGeneratedImplementation()). R8 doesn't know about reflection calls, so it was removing the class and its constructor entirely from the release build.

The fix: -keep class **.*_Impl tells R8 to never touch those generated classes.

Now rebuild the signed AAB in Android Studio and re-upload — the crash should be gone. Also bump versionCode to 20 before re-uploading since 19 was already submitted.