### PR TITLE
Move chooser order control into Settings and overlay chooser instruction

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 20
-        versionName "1.3.0"
+        versionCode 21
+        versionName "1.4.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.material:material:1.12.0'
+    debugImplementation 'androidx.fragment:fragment-testing:1.6.2'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
     testImplementation 'androidx.room:room-testing:2.6.1'
     testImplementation 'androidx.test:core:1.5.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,9 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:windowSoftInputMode="adjustPan|adjustResize|stateAlwaysHidden|stateHidden"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustPan|adjustResize|stateAlwaysHidden|stateHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/nicue/onetwo/MainActivity.java
+++ b/app/src/main/java/com/nicue/onetwo/MainActivity.java
@@ -3,7 +3,6 @@ package com.nicue.onetwo;
 import android.os.Bundle;
 import android.view.WindowManager;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.navigation.NavController;

--- a/app/src/main/java/com/nicue/onetwo/OneTwoApplication.java
+++ b/app/src/main/java/com/nicue/onetwo/OneTwoApplication.java
@@ -17,4 +17,8 @@ public class OneTwoApplication extends Application {
     public AppContainer getAppContainer() {
         return appContainer;
     }
+
+    public void setAppContainerForTesting(AppContainer appContainer) {
+        this.appContainer = appContainer;
+    }
 }

--- a/app/src/main/java/com/nicue/onetwo/core/AppContainer.java
+++ b/app/src/main/java/com/nicue/onetwo/core/AppContainer.java
@@ -13,30 +13,32 @@ import com.nicue.onetwo.data.settings.SettingsRepository;
 import com.nicue.onetwo.data.timer.TimerStateStore;
 import com.nicue.onetwo.db.TaskContract;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 public class AppContainer {
-    private final ExecutorService ioExecutor = Executors.newSingleThreadExecutor();
     private final CounterRepository counterRepository;
     private final DiceRepository diceRepository;
     private final SettingsRepository settingsRepository;
     private final TimerStateStore timerStateStore;
 
     public AppContainer(Application application) {
-        CounterDatabase counterDatabase = Room.databaseBuilder(
+        this(application, Room.databaseBuilder(
                 application,
                 CounterDatabase.class,
                 TaskContract.DB_NAME
-        ).build();
-        counterRepository = new CounterRepository(counterDatabase.counterDao(), ioExecutor);
-        diceRepository = new DiceRepository(
+        ).build(), Executors.newSingleThreadExecutor());
+    }
+
+    public AppContainer(Application application, CounterDatabase counterDatabase, Executor executor) {
+        this.counterRepository = new CounterRepository(counterDatabase.counterDao(), executor);
+        this.diceRepository = new DiceRepository(
                 new DicePrefsDataSource(application.getApplicationContext())
         );
-        settingsRepository = new SettingsRepository(
+        this.settingsRepository = new SettingsRepository(
                 new SettingsPrefsDataSource(application.getApplicationContext())
         );
-        timerStateStore = new TimerStateStore();
+        this.timerStateStore = new TimerStateStore();
     }
 
     public CounterRepository getCounterRepository() {

--- a/app/src/main/java/com/nicue/onetwo/data/settings/SettingsPrefsDataSource.java
+++ b/app/src/main/java/com/nicue/onetwo/data/settings/SettingsPrefsDataSource.java
@@ -7,6 +7,7 @@ public class SettingsPrefsDataSource {
     private static final String PREF_FILE = "SETTINGS_PREFS";
     private static final String KEY_ALWAYS_ON = "always_on";
     private static final String KEY_DARK_MODE = "dark_mode";
+    private static final String KEY_CHOOSER_ORDER = "chooser_order";
     private final SharedPreferences sharedPreferences;
 
     public SettingsPrefsDataSource(Context context) {
@@ -27,5 +28,13 @@ public class SettingsPrefsDataSource {
 
     public void setDarkModeEnabled(boolean enabled) {
         sharedPreferences.edit().putBoolean(KEY_DARK_MODE, enabled).apply();
+    }
+
+    public boolean isChooserOrderEnabled() {
+        return sharedPreferences.getBoolean(KEY_CHOOSER_ORDER, false);
+    }
+
+    public void setChooserOrderEnabled(boolean enabled) {
+        sharedPreferences.edit().putBoolean(KEY_CHOOSER_ORDER, enabled).apply();
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/data/settings/SettingsRepository.java
+++ b/app/src/main/java/com/nicue/onetwo/data/settings/SettingsRepository.java
@@ -28,6 +28,14 @@ public class SettingsRepository {
         dataSource.setDarkModeEnabled(enabled);
     }
 
+    public boolean isChooserOrderEnabled() {
+        return dataSource.isChooserOrderEnabled();
+    }
+
+    public void setChooserOrderEnabled(boolean enabled) {
+        dataSource.setChooserOrderEnabled(enabled);
+    }
+
     public void applyNightMode() {
         boolean darkModeEnabled = isDarkModeEnabled();
         AppCompatDelegate.setDefaultNightMode(

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -18,7 +18,7 @@ import com.nicue.onetwo.data.settings.SettingsRepository;
 import com.nicue.onetwo.databinding.ChooserLayoutBinding;
 
 public class ChooserFragment extends Fragment {
-    private static final long INSTRUCTION_HIDE_DELAY_MS = 1500L;
+    private static final long INSTRUCTION_HIDE_DELAY_MS = 800L;
 
     private ChooserLayoutBinding binding;
     private ChooserViewModel viewModel;

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -1,7 +1,10 @@
 package com.nicue.onetwo.ui.chooser;
 
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -15,8 +18,19 @@ import com.nicue.onetwo.data.settings.SettingsRepository;
 import com.nicue.onetwo.databinding.ChooserLayoutBinding;
 
 public class ChooserFragment extends Fragment {
+    private static final long INSTRUCTION_HIDE_DELAY_MS = 1500L;
+
     private ChooserLayoutBinding binding;
     private ChooserViewModel viewModel;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final Runnable hideInstructionRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (binding != null) {
+                binding.chooserInstruction.setVisibility(View.GONE);
+            }
+        }
+    };
 
     @Nullable
     @Override
@@ -41,6 +55,16 @@ public class ChooserFragment extends Fragment {
                 binding.chooserView.setChoosingOrder(value);
             }
         });
+        binding.chooserView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View touchedView, MotionEvent event) {
+                int action = event.getActionMasked();
+                if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN) {
+                    scheduleInstructionHide();
+                }
+                return false;
+            }
+        });
     }
 
     @Override
@@ -53,7 +77,16 @@ public class ChooserFragment extends Fragment {
 
     @Override
     public void onDestroyView() {
+        handler.removeCallbacks(hideInstructionRunnable);
         binding = null;
         super.onDestroyView();
+    }
+
+    private void scheduleInstructionHide() {
+        if (binding.chooserInstruction.getVisibility() != View.VISIBLE) {
+            return;
+        }
+        handler.removeCallbacks(hideInstructionRunnable);
+        handler.postDelayed(hideInstructionRunnable, INSTRUCTION_HIDE_DELAY_MS);
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -4,13 +4,14 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CompoundButton;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.nicue.onetwo.OneTwoApplication;
+import com.nicue.onetwo.data.settings.SettingsRepository;
 import com.nicue.onetwo.databinding.ChooserLayoutBinding;
 
 public class ChooserFragment extends Fragment {
@@ -28,24 +29,26 @@ public class ChooserFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        viewModel = new ViewModelProvider(this, new ChooserViewModelFactory())
+        SettingsRepository settingsRepository = ((OneTwoApplication) requireActivity().getApplication())
+                .getAppContainer()
+                .getSettingsRepository();
+        viewModel = new ViewModelProvider(this, new ChooserViewModelFactory(settingsRepository))
                 .get(ChooserViewModel.class);
-        binding.chooserModeSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                viewModel.setChoosingOrder(isChecked);
-            }
-        });
         viewModel.getChoosingOrder().observe(getViewLifecycleOwner(), new androidx.lifecycle.Observer<Boolean>() {
             @Override
             public void onChanged(Boolean choosingOrder) {
                 boolean value = Boolean.TRUE.equals(choosingOrder);
-                if (binding.chooserModeSwitch.isChecked() != value) {
-                    binding.chooserModeSwitch.setChecked(value);
-                }
                 binding.chooserView.setChoosingOrder(value);
             }
         });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (viewModel != null) {
+            viewModel.refreshChoosingOrder();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserViewModel.java
@@ -1,27 +1,25 @@
 package com.nicue.onetwo.ui.chooser;
 
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.SavedStateHandle;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
-public class ChooserViewModel extends ViewModel {
-    private static final String KEY_CHOOSING_ORDER = "choosing_order";
-    private final SavedStateHandle savedStateHandle;
-    private final LiveData<Boolean> choosingOrder;
+import com.nicue.onetwo.data.settings.SettingsRepository;
 
-    public ChooserViewModel(SavedStateHandle savedStateHandle) {
-        this.savedStateHandle = savedStateHandle;
-        if (savedStateHandle.get(KEY_CHOOSING_ORDER) == null) {
-            savedStateHandle.set(KEY_CHOOSING_ORDER, false);
-        }
-        choosingOrder = savedStateHandle.getLiveData(KEY_CHOOSING_ORDER);
+public class ChooserViewModel extends ViewModel {
+    private final SettingsRepository settingsRepository;
+    private final MutableLiveData<Boolean> choosingOrder = new MutableLiveData<>();
+
+    public ChooserViewModel(SettingsRepository settingsRepository) {
+        this.settingsRepository = settingsRepository;
+        refreshChoosingOrder();
     }
 
     public LiveData<Boolean> getChoosingOrder() {
         return choosingOrder;
     }
 
-    public void setChoosingOrder(boolean choosingOrder) {
-        savedStateHandle.set(KEY_CHOOSING_ORDER, choosingOrder);
+    public void refreshChoosingOrder() {
+        choosingOrder.setValue(settingsRepository.isChooserOrderEnabled());
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserViewModelFactory.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserViewModelFactory.java
@@ -1,20 +1,25 @@
 package com.nicue.onetwo.ui.chooser;
 
 import androidx.annotation.NonNull;
-import androidx.lifecycle.SavedStateHandle;
-import androidx.lifecycle.SavedStateHandleSupport;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.nicue.onetwo.data.settings.SettingsRepository;
+
 public class ChooserViewModelFactory implements ViewModelProvider.Factory {
+    private final SettingsRepository settingsRepository;
+
+    public ChooserViewModelFactory(SettingsRepository settingsRepository) {
+        this.settingsRepository = settingsRepository;
+    }
+
     @NonNull
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass,
                                           @NonNull androidx.lifecycle.viewmodel.CreationExtras extras) {
         if (modelClass.isAssignableFrom(ChooserViewModel.class)) {
-            SavedStateHandle savedStateHandle = SavedStateHandleSupport.createSavedStateHandle(extras);
-            return (T) new ChooserViewModel(savedStateHandle);
+            return (T) new ChooserViewModel(settingsRepository);
         }
         throw new IllegalArgumentException("Unknown ViewModel class " + modelClass.getName());
     }

--- a/app/src/main/java/com/nicue/onetwo/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/settings/SettingsFragment.java
@@ -29,6 +29,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
         configureAlwaysOnPreference();
         configureDarkModePreference();
+        configureChooserOrderPreference();
     }
 
     private void configureAlwaysOnPreference() {
@@ -62,6 +63,23 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 boolean enabled = (Boolean) newValue;
                 settingsRepository.setDarkModeEnabled(enabled);
                 getSettingsApplier().applyDarkMode(enabled);
+                return true;
+            }
+        });
+    }
+
+    private void configureChooserOrderPreference() {
+        SwitchPreferenceCompat preference = findPreference("chooser_order");
+        if (preference == null) {
+            return;
+        }
+        preference.setPersistent(false);
+        preference.setChecked(settingsRepository.isChooserOrderEnabled());
+        preference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(@NonNull Preference preference, Object newValue) {
+                boolean enabled = (Boolean) newValue;
+                settingsRepository.setChooserOrderEnabled(enabled);
                 return true;
             }
         });

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -408,8 +408,7 @@ public class TouchDisplayView extends View {
                 if (choosingOrder) {
                     int place = indexInArray(randomArray, id) + 1;
                     mTextPaint.setColor(Color.WHITE);
-                    canvas.drawText(String.valueOf(place), data.x,
-                            data.y - half_r - radius - mOrderLabelOffset, mTextPaint);
+                    drawOrderLabels(canvas, String.valueOf(place), data.x, data.y - half_r, radius);
                     drawBig = false;
                 }
             }
@@ -424,6 +423,50 @@ public class TouchDisplayView extends View {
                     mCirclePaint);
         }
 
+    }
+
+    private void drawOrderLabels(Canvas canvas, String label, float centerX, float centerY, float radius) {
+        float textSize = mTextPaint.getTextSize();
+        float halfTextWidth = mTextPaint.measureText(label) / 2f;
+        float labelDistance = radius + mOrderLabelOffset;
+        float baselineCenterOffset = textSize / 3f;
+
+        float minX = halfTextWidth;
+        float maxX = getWidth() - halfTextWidth;
+        float minBaselineY = textSize;
+        float maxBaselineY = getHeight() - baselineCenterOffset;
+
+        drawRotatedOrderLabel(canvas, label,
+                clamp(centerX, minX, maxX),
+                clamp(centerY - labelDistance + baselineCenterOffset, minBaselineY, maxBaselineY),
+                0f, baselineCenterOffset);
+        drawRotatedOrderLabel(canvas, label,
+                clamp(centerX + labelDistance, minX, maxX),
+                clamp(centerY + baselineCenterOffset, minBaselineY, maxBaselineY),
+                90f, baselineCenterOffset);
+        drawRotatedOrderLabel(canvas, label,
+                clamp(centerX, minX, maxX),
+                clamp(centerY + labelDistance + baselineCenterOffset, minBaselineY, maxBaselineY),
+                180f, baselineCenterOffset);
+        drawRotatedOrderLabel(canvas, label,
+                clamp(centerX - labelDistance, minX, maxX),
+                clamp(centerY + baselineCenterOffset, minBaselineY, maxBaselineY),
+                -90f, baselineCenterOffset);
+    }
+
+    private void drawRotatedOrderLabel(Canvas canvas, String label, float x, float baselineY,
+                                       float degrees, float baselineCenterOffset) {
+        canvas.save();
+        canvas.rotate(degrees, x, baselineY - baselineCenterOffset);
+        canvas.drawText(label, x, baselineY, mTextPaint);
+        canvas.restore();
+    }
+
+    private float clamp(float value, float min, float max) {
+        if (max < min) {
+            return min;
+        }
+        return Math.max(min, Math.min(value, max));
     }
 
     private void startSelectionRevealAnimation() {

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -31,6 +31,9 @@ public class TouchDisplayView extends View {
     //private int fingers = 0;
     private Random random = new Random();
     private static final long SELECTION_REVEAL_DURATION_MS = 650L;
+    private static final int SELECTED_TOUCH_ALPHA = 255;
+    private static final int DIMMED_TOUCH_ALPHA = 105;
+    private static final int TOUCH_HALO_ALPHA = 125;
     private int chosenColor = 0;
     private int chosenId = -1;
     private int[] randomArray = {};
@@ -358,8 +361,14 @@ public class TouchDisplayView extends View {
     protected void drawCircle(Canvas canvas, int id, TouchHistory data) {
         // select the color based on the id
         int color = COLORS[id % COLORS.length];
+        int touchAlpha = alreadyChosen && chosenId != id
+                ? DIMMED_TOUCH_ALPHA
+                : SELECTED_TOUCH_ALPHA;
+        int haloAlpha = alreadyChosen && chosenId != id
+                ? DIMMED_TOUCH_ALPHA / 2
+                : TOUCH_HALO_ALPHA;
         mCirclePaint.setColor(color);
-        mCirclePaint.setAlpha(255);
+        mCirclePaint.setAlpha(touchAlpha);
         boolean drawBig = true;
 
 
@@ -411,7 +420,7 @@ public class TouchDisplayView extends View {
                 mCirclePaint);
 
         if(drawBig) {
-            mCirclePaint.setAlpha(125);
+            mCirclePaint.setAlpha(haloAlpha);
             canvas.drawCircle(data.x, (data.y) - half_r, radius * 2f,
                     mCirclePaint);
         }

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -1,6 +1,7 @@
 package com.nicue.onetwo.utils;
 
 
+import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
@@ -12,6 +13,7 @@ import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.animation.DecelerateInterpolator;
 import android.os.Vibrator;
 
 import com.nicue.onetwo.R;
@@ -28,9 +30,15 @@ public class TouchDisplayView extends View {
     private boolean choosingOrder = false;
     //private int fingers = 0;
     private Random random = new Random();
+    private static final long SELECTION_REVEAL_DURATION_MS = 650L;
     private int chosenColor = 0;
     private int chosenId = -1;
     private int[] randomArray = {};
+    private float selectionRevealProgress = 1f;
+    private float selectionRevealCenterX = 0f;
+    private float selectionRevealCenterY = 0f;
+    private float selectionRevealMaxRadius = 0f;
+    private ValueAnimator selectionRevealAnimator;
 
     private int backgroundColorOverride = getResources().getColor(R.color.overrideBackground);
 
@@ -56,6 +64,8 @@ public class TouchDisplayView extends View {
                 shuffleArray(randomArray);
                 chosenId = randomArray[0];
                 chosenColor = COLORS[chosenId % COLORS.length];
+                updateSelectionRevealBounds();
+                startSelectionRevealAnimation();
                 Vibrator v = (Vibrator) getContext().getSystemService(Context.VIBRATOR_SERVICE);
                 long[] pattern = {0,20,10,50};
                 v.vibrate(pattern, -1);
@@ -222,14 +232,14 @@ public class TouchDisplayView extends View {
                 data.recycle();
 
                 mHasTouch = false;
+                resetSelection();
 
                 break;
             }
 
             case MotionEvent.ACTION_POINTER_UP: {
                 fingersDown = false;
-                alreadyChosen = false;
-                randomArray = new int[0];
+                resetSelection();
                 //fingers --;
                 handler.removeCallbacks(runnable);
                 /*
@@ -278,13 +288,14 @@ public class TouchDisplayView extends View {
 
         // Canvas background color depends on whether there is an active touch
         if (mHasTouch) {
-            canvas.drawColor(backgroundColorOverride);
             if (alreadyChosen){
                 canvas.drawColor(chosenColor);
+                drawSelectionReveal(canvas);
+            } else {
+                canvas.drawColor(backgroundColorOverride);
             }
         }else{
-            alreadyChosen = false;
-            randomArray = new int[0];
+            resetSelection();
         }
 
         // loop through all active touches and draw them
@@ -314,6 +325,7 @@ public class TouchDisplayView extends View {
     private Paint mTextPaint = new Paint();
     private Paint mStrokePaint = new Paint();
     private Paint mTransStrokePaint = new Paint();
+    private Paint mRevealPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
 
 
@@ -347,6 +359,7 @@ public class TouchDisplayView extends View {
         // select the color based on the id
         int color = COLORS[id % COLORS.length];
         mCirclePaint.setColor(color);
+        mCirclePaint.setAlpha(255);
         boolean drawBig = true;
 
 
@@ -403,6 +416,68 @@ public class TouchDisplayView extends View {
                     mCirclePaint);
         }
 
+    }
+
+    private void startSelectionRevealAnimation() {
+        if (selectionRevealAnimator != null) {
+            selectionRevealAnimator.cancel();
+        }
+        selectionRevealProgress = 0f;
+        selectionRevealAnimator = ValueAnimator.ofFloat(0f, 1f);
+        selectionRevealAnimator.setDuration(SELECTION_REVEAL_DURATION_MS);
+        selectionRevealAnimator.setInterpolator(new DecelerateInterpolator());
+        selectionRevealAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+            @Override
+            public void onAnimationUpdate(ValueAnimator animation) {
+                selectionRevealProgress = (Float) animation.getAnimatedValue();
+                invalidate();
+            }
+        });
+        selectionRevealAnimator.start();
+    }
+
+    private void drawSelectionReveal(Canvas canvas) {
+        if (selectionRevealProgress >= 1f) {
+            return;
+        }
+
+        TouchHistory chosenTouch = mTouches.get(chosenId);
+        if (chosenTouch == null) {
+            return;
+        }
+
+        float radius = chosenTouch.pressure * mCircleRadius;
+        float centerX = chosenTouch.x;
+        float centerY = chosenTouch.y - (radius / 2f);
+        float revealRadius = maxDistanceToCorner(centerX, centerY) * (1f - selectionRevealProgress);
+
+        mRevealPaint.setColor(backgroundColorOverride);
+        canvas.drawCircle(centerX, centerY, revealRadius, mRevealPaint);
+    }
+
+    private float maxDistanceToCorner(float x, float y) {
+        float topLeft = distance(x, y, 0f, 0f);
+        float topRight = distance(x, y, getWidth(), 0f);
+        float bottomLeft = distance(x, y, 0f, getHeight());
+        float bottomRight = distance(x, y, getWidth(), getHeight());
+        return Math.max(Math.max(topLeft, topRight), Math.max(bottomLeft, bottomRight));
+    }
+
+    private float distance(float startX, float startY, float endX, float endY) {
+        float xDiff = startX - endX;
+        float yDiff = startY - endY;
+        return (float) Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
+    }
+
+    private void resetSelection() {
+        alreadyChosen = false;
+        chosenId = -1;
+        randomArray = new int[0];
+        selectionRevealProgress = 1f;
+        if (selectionRevealAnimator != null) {
+            selectionRevealAnimator.cancel();
+            selectionRevealAnimator = null;
+        }
     }
 
     public int indexInArray(int[] arr, int n){

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -3,7 +3,6 @@ package com.nicue.onetwo.utils;
 
 import android.animation.ValueAnimator;
 import android.content.Context;
-import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -13,6 +12,7 @@ import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
 import android.os.Vibrator;
 
@@ -29,11 +29,11 @@ public class TouchDisplayView extends View {
     private boolean alreadyChosen = false;
     private boolean choosingOrder = false;
     //private int fingers = 0;
-    private Random random = new Random();
     private static final long SELECTION_REVEAL_DURATION_MS = 650L;
     private static final int SELECTED_TOUCH_ALPHA = 255;
     private static final int DIMMED_TOUCH_ALPHA = 105;
     private static final int TOUCH_HALO_ALPHA = 125;
+    private static final float ORDER_LABEL_OFFSET_DP = 22f;
     private int chosenColor = 0;
     private int chosenId = -1;
     private int[] randomArray = {};
@@ -43,12 +43,24 @@ public class TouchDisplayView extends View {
     private float selectionRevealMaxRadius = 0f;
     private ValueAnimator selectionRevealAnimator;
 
+    private float pulseValue = 0f;
+    private ValueAnimator pulseAnimator;
+
     private int backgroundColorOverride = getResources().getColor(R.color.overrideBackground);
 
 
     private final int[] COLORS = {
-            0xFF03A9F4, 0xFF009688, 0xFF8BC34A, 0xFFF44336, 0xFFFF9800,
-            0xFFFF5722, 0xFF795548, 0xFFAFB3A0, 0xFFE91E63, 0xFF9C27B0};
+            0xFF6750A4, // M3 Purple
+            0xFF0061A4, // M3 Blue
+            0xFF006A6A, // M3 Teal
+            0xFF386A20, // M3 Green
+            0xFF8B5000, // M3 Orange
+            0xFFBA1A1A, // M3 Red
+            0xFF984061, // M3 Pink
+            0xFF4A6572, // M3 Blue Gray
+            0xFF525E75, // M3 Steel
+            0xFF7D5260  // M3 Maroon
+    };
 
 
     //A Handler to check if all fingers have been pressed down for x time
@@ -69,6 +81,7 @@ public class TouchDisplayView extends View {
                 chosenColor = COLORS[chosenId % COLORS.length];
                 updateSelectionRevealBounds();
                 startSelectionRevealAnimation();
+                startPulseAnimation();
                 Vibrator v = (Vibrator) getContext().getSystemService(Context.VIBRATOR_SERVICE);
                 long[] pattern = {0,20,10,50};
                 v.vibrate(pattern, -1);
@@ -160,6 +173,13 @@ public class TouchDisplayView extends View {
         mTouches = new SparseArray<TouchHistory>(10);
 
         initialisePaint();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        handler.removeCallbacks(runnable);
+        resetSelection();
+        super.onDetachedFromWindow();
     }
 
     // BEGIN_INCLUDE(onTouchEvent)
@@ -322,12 +342,15 @@ public class TouchDisplayView extends View {
 
     // calculated radiuses in px
     private float mCircleRadius;
-    private int mScreenWidth;
+    private float mPulseBaseOffset;
+    private float mPulseOffset;
+    private float mPulseFadeRange;
+    private float mOrderLabelOffset;
 
-    private Paint mCirclePaint = new Paint();
-    private Paint mTextPaint = new Paint();
-    private Paint mStrokePaint = new Paint();
-    private Paint mTransStrokePaint = new Paint();
+    private Paint mCirclePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Paint mTextPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Paint mStrokePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Paint mTransStrokePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private Paint mRevealPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
 
@@ -339,23 +362,24 @@ public class TouchDisplayView extends View {
         // Calculate radiuses i n px from dp based on screen density
         float density = getResources().getDisplayMetrics().density;
         mCircleRadius = CIRCLE_RADIUS_DP * density;
-        //we want to know the screen width to make the white text remain in the screen
-        Configuration configuration = getContext().getResources().getConfiguration();
-        mScreenWidth = configuration.smallestScreenWidthDp * (int) density ;
-        //mCircleHistoricalRadius = CIRCLE_HISTORICAL_RADIUS_DP * density;
+        mPulseBaseOffset = 35f * density;
+        mPulseOffset = 20f * density;
+        mPulseFadeRange = 180f * density;
+        mOrderLabelOffset = ORDER_LABEL_OFFSET_DP * density;
 
         // Setup text paint for circle label
-        mTextPaint.setTextSize(30f*density);
-        mStrokePaint.setTextSize(30f*density);
+        mTextPaint.setTextSize(18f*density);
         mTextPaint.setColor(Color.WHITE);
-        mStrokePaint.setColor(Color.WHITE);
-        mTransStrokePaint.setColor(Color.WHITE);
-        mTextPaint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
-        mStrokePaint.setStyle(Paint.Style.STROKE);
-        mStrokePaint.setStrokeWidth(6f* density);
-        mTransStrokePaint.setStyle(Paint.Style.STROKE);
-        mTransStrokePaint.setStrokeWidth(6f* density);
+        mTextPaint.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        mTextPaint.setTextAlign(Paint.Align.CENTER);
 
+        mStrokePaint.setColor(Color.WHITE);
+        mStrokePaint.setStyle(Paint.Style.STROKE);
+        mStrokePaint.setStrokeWidth(3f* density);
+
+        mTransStrokePaint.setColor(Color.WHITE);
+        mTransStrokePaint.setStyle(Paint.Style.STROKE);
+        mTransStrokePaint.setStrokeWidth(3f* density);
     }
 
     protected void drawCircle(Canvas canvas, int id, TouchHistory data) {
@@ -377,40 +401,15 @@ public class TouchDisplayView extends View {
 
 
         if(alreadyChosen){
-            int place = indexInArray(randomArray, id) +1;
             if (chosenId == id){
-                //We draw he circle first to be under the text
-                canvas.drawCircle(data.x, (data.y) - half_r, radius + 10,
-                        mStrokePaint);
-                //Here we can add more circles for more visibility of chosen one;
-                mTransStrokePaint.setAlpha(125);
-                canvas.drawCircle(data.x, (data.y) - half_r, radius + 50,
-                        mTransStrokePaint);
-                mTransStrokePaint.setAlpha(50);
-                canvas.drawCircle(data.x, (data.y) - half_r, radius + 90,
-                        mTransStrokePaint);
-                if ((data.x + radius + 50)<mScreenWidth ) {
-                    canvas.drawText("Chosen", data.x + radius, data.y
-                            - radius, mTextPaint);
-                }else{
-                    canvas.drawText("Chosen", data.x - radius -100, data.y
-                            - radius - 90, mTextPaint);
-                }
-
+                drawPulsingConcentricCircles(canvas, data.x, data.y, radius, half_r);
                 drawBig = false;
             }else{ // With this line we are giving it a random order
                 if (choosingOrder) {
-                    if ((data.x + radius + 20)<mScreenWidth ) {
-                        canvas.drawText(String.valueOf(place), data.x + radius + 20, data.y
-                                - radius - 20, mTextPaint);
-                    }else{
-                        canvas.drawText(String.valueOf(place), data.x - radius-40, data.y
-                                        - radius -20, mTextPaint);
-                    }
-
-                    // uncomment this to add a second indicator of order
-                    //canvas.drawText(String.valueOf(place), data.x - radius-20, data.y
-                    //        + radius +20, mTextPaint);
+                    int place = indexInArray(randomArray, id) + 1;
+                    mTextPaint.setColor(Color.WHITE);
+                    canvas.drawText(String.valueOf(place), data.x,
+                            data.y - half_r - radius - mOrderLabelOffset, mTextPaint);
                     drawBig = false;
                 }
             }
@@ -487,6 +486,40 @@ public class TouchDisplayView extends View {
         return (float) Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
     }
 
+    private void startPulseAnimation() {
+        if (pulseAnimator != null) {
+            pulseAnimator.cancel();
+        }
+        pulseAnimator = ValueAnimator.ofFloat(0f, 1f);
+        pulseAnimator.setDuration(1200L);
+        pulseAnimator.setRepeatCount(ValueAnimator.INFINITE);
+        pulseAnimator.setRepeatMode(ValueAnimator.REVERSE);
+        pulseAnimator.setInterpolator(new AccelerateDecelerateInterpolator());
+        pulseAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+            @Override
+            public void onAnimationUpdate(ValueAnimator animation) {
+                pulseValue = (Float) animation.getAnimatedValue();
+                invalidate();
+            }
+        });
+        pulseAnimator.start();
+    }
+
+    private void drawPulsingConcentricCircles(Canvas canvas, float x, float y, float radius, float half_r) {
+        for (int i = 0; i < 3; i++) {
+            float baseOffset = (i + 1) * mPulseBaseOffset;
+            float pulseOffset = pulseValue * mPulseOffset;
+            float circleRadius = radius + baseOffset + pulseOffset;
+            
+            // Fade out as they get larger
+            int alpha = (int) (160 * (1.0f - (circleRadius - radius) / (radius + mPulseFadeRange)));
+            if (alpha < 0) alpha = 0;
+            
+            mTransStrokePaint.setAlpha(alpha);
+            canvas.drawCircle(x, y - half_r, circleRadius, mTransStrokePaint);
+        }
+    }
+
     private void resetSelection() {
         alreadyChosen = false;
         chosenId = -1;
@@ -499,6 +532,11 @@ public class TouchDisplayView extends View {
             selectionRevealAnimator.cancel();
             selectionRevealAnimator = null;
         }
+        if (pulseAnimator != null) {
+            pulseAnimator.cancel();
+            pulseAnimator = null;
+        }
+        pulseValue = 0f;
     }
 
     public int indexInArray(int[] arr, int n){

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -441,18 +441,27 @@ public class TouchDisplayView extends View {
             return;
         }
 
+        if (selectionRevealMaxRadius <= 0f) {
+            return;
+        }
+
+        float revealRadius = selectionRevealMaxRadius * (1f - selectionRevealProgress);
+
+        mRevealPaint.setColor(backgroundColorOverride);
+        canvas.drawCircle(selectionRevealCenterX, selectionRevealCenterY, revealRadius, mRevealPaint);
+    }
+
+    private void updateSelectionRevealBounds() {
         TouchHistory chosenTouch = mTouches.get(chosenId);
         if (chosenTouch == null) {
+            selectionRevealMaxRadius = 0f;
             return;
         }
 
         float radius = chosenTouch.pressure * mCircleRadius;
-        float centerX = chosenTouch.x;
-        float centerY = chosenTouch.y - (radius / 2f);
-        float revealRadius = maxDistanceToCorner(centerX, centerY) * (1f - selectionRevealProgress);
-
-        mRevealPaint.setColor(backgroundColorOverride);
-        canvas.drawCircle(centerX, centerY, revealRadius, mRevealPaint);
+        selectionRevealCenterX = chosenTouch.x;
+        selectionRevealCenterY = chosenTouch.y - (radius / 2f);
+        selectionRevealMaxRadius = maxDistanceToCorner(selectionRevealCenterX, selectionRevealCenterY);
     }
 
     private float maxDistanceToCorner(float x, float y) {
@@ -474,6 +483,9 @@ public class TouchDisplayView extends View {
         chosenId = -1;
         randomArray = new int[0];
         selectionRevealProgress = 1f;
+        selectionRevealCenterX = 0f;
+        selectionRevealCenterY = 0f;
+        selectionRevealMaxRadius = 0f;
         if (selectionRevealAnimator != null) {
             selectionRevealAnimator.cancel();
             selectionRevealAnimator = null;

--- a/app/src/main/res/layout/chooser_layout.xml
+++ b/app/src/main/res/layout/chooser_layout.xml
@@ -16,23 +16,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/chooser_mode_switch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_s"
-        android:text="@string/order"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chooser_instruction" />
-
     <FrameLayout
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginTop="@dimen/space_s"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chooser_mode_switch">
+        app:layout_constraintTop_toBottomOf="@id/chooser_instruction">
 
         <com.nicue.onetwo.utils.TouchDisplayView
             android:id="@+id/chooser_view"

--- a/app/src/main/res/layout/chooser_layout.xml
+++ b/app/src/main/res/layout/chooser_layout.xml
@@ -4,31 +4,31 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/chooser_instruction"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_m"
-        android:text="@string/touch_me"
-        android:textAppearance="?attr/textAppearanceBodyLarge"
-        android:textColor="?attr/colorOnSurfaceVariant"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <FrameLayout
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="@dimen/space_s"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chooser_instruction">
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.nicue.onetwo.utils.TouchDisplayView
             android:id="@+id/chooser_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TextView
+            android:id="@+id/chooser_instruction"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="false"
+            android:focusable="false"
+            android:gravity="center"
+            android:padding="@dimen/space_m"
+            android:text="@string/touch_me"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?attr/colorOnSurfaceVariant" />
     </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dice_item.xml
+++ b/app/src/main/res/layout/dice_item.xml
@@ -20,7 +20,11 @@
             android:id="@+id/tv_faces"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:visibility="gone" />
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <FrameLayout
             android:id="@+id/dice_face_container"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -31,4 +31,6 @@
     <string name="always_on_title">Mantener pantalla encendida</string>
     <string name="misc_header">Misc</string>
     <string name="always_on_summary">Mantener pantalla encendida</string>
+    <string name="chooser_order_title">Orden del selector</string>
+    <string name="chooser_order_summary">Elegir dedos por orden de colocación</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -31,5 +31,7 @@
     <string name="always_on_title">Garder l\'écran allumé</string>
     <string name="misc_header">Misc</string>
     <string name="always_on_summary">Garder l\'écran allumé</string>
+    <string name="chooser_order_title">Ordre du choix</string>
+    <string name="chooser_order_summary">Choisir les doigts dans l\'ordre de pose</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -31,5 +31,7 @@
     <string name="always_on_title">Keep Screen on</string>
     <string name="misc_header">Misc</string>
     <string name="always_on_summary">Keep Screen on</string>
+    <string name="chooser_order_title">選択順</string>
+    <string name="chooser_order_summary">指を置いた順に選択します</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="always_on_summary">Keep screen on while using</string>
     <string name="dark_mode_title" translatable="false">Dark Mode</string>
     <string name="dark_mode_summary" translatable="false">Use dark mode theme</string>
+    <string name="chooser_order_title">Chooser order</string>
+    <string name="chooser_order_summary">Choose fingers in placement order</string>
 
 
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -14,6 +14,12 @@
             app:summary="@string/dark_mode_summary"
             app:title="@string/dark_mode_title" />
 
+        <SwitchPreferenceCompat
+            app:key="chooser_order"
+            app:defaultValue="false"
+            app:summary="@string/chooser_order_summary"
+            app:title="@string/chooser_order_title" />
+
     </PreferenceCategory>
 
 

--- a/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserViewModelTest.java
@@ -1,0 +1,41 @@
+package com.nicue.onetwo.ui.chooser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.nicue.onetwo.LiveDataTestUtil;
+import com.nicue.onetwo.data.settings.SettingsPrefsDataSource;
+import com.nicue.onetwo.data.settings.SettingsRepository;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class ChooserViewModelTest {
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    @Test
+    public void refreshChoosingOrder_readsPersistedSetting() throws InterruptedException {
+        Context context = ApplicationProvider.getApplicationContext();
+        SettingsRepository settingsRepository = new SettingsRepository(new SettingsPrefsDataSource(context));
+        settingsRepository.setChooserOrderEnabled(false);
+
+        ChooserViewModel viewModel = new ChooserViewModel(settingsRepository);
+        assertFalse(LiveDataTestUtil.getValue(viewModel.getChoosingOrder()));
+
+        settingsRepository.setChooserOrderEnabled(true);
+        viewModel.refreshChoosingOrder();
+
+        assertTrue(LiveDataTestUtil.getValue(viewModel.getChoosingOrder()));
+    }
+}

--- a/app/src/test/java/com/nicue/onetwo/ui/counter/CounterFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/counter/CounterFragmentTest.java
@@ -13,7 +13,9 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.nicue.onetwo.OneTwoApplication;
 import com.nicue.onetwo.R;
+import com.nicue.onetwo.data.counter.CounterDatabase;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,12 +30,25 @@ public class CounterFragmentTest {
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
+    private CounterDatabase testDb;
+
     @Before
     public void setUp() {
-        // We ensure the application container is ready
-        // In a real project, we might use a TestAppContainer or Hilt
         OneTwoApplication app = ApplicationProvider.getApplicationContext();
-        assertNotNull(app.getAppContainer());
+        
+        // Create a test-friendly database that allows main thread queries
+        testDb = androidx.room.Room.inMemoryDatabaseBuilder(
+                app, CounterDatabase.class)
+                .allowMainThreadQueries()
+                .build();
+        
+        // Inject the test container with a synchronous executor
+        app.setAppContainerForTesting(new com.nicue.onetwo.core.AppContainer(app, testDb, Runnable::run));
+    }
+
+    @After
+    public void tearDown() {
+        testDb.close();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Moved the chooser order toggle out of the Choose screen and into Settings, backed by shared preferences.
- Switched the chooser instruction to a centered overlay on top of `TouchDisplayView` so hiding it does not shift the touch area.
- Added a focused chooser ViewModel test for reading the persisted chooser order setting.

## Testing
- `./gradlew assembleDebug` passed.
- `./gradlew testDebugUnitTest` is still blocked by an existing missing test dependency in `CounterFragmentTest` (`FragmentScenario`).