### PR TITLE
Add Spotless formatting and Checkstyle linting

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,34 @@
+name: Android CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: android-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run formatter, linter, and unit tests
+        run: ./gradlew --no-daemon qualityCheck testDebugUnitTest

--- a/README.md
+++ b/README.md
@@ -14,13 +14,23 @@ There's three main ways to get OneTwo
 ## How to Contribute
 If you want to contribute to OneTwo, fill an Issue saying what would you like to change and if you want to be a contributor. Once you are a collaborator, you can commit and push, or do a pull request if you would like to!
 
+## Development
+
+Useful Gradle tasks:
+
+* `./gradlew format` formats changed Java, Gradle, Markdown, properties, and XML files.
+* `./gradlew formatCheck` checks changed-file formatting without changing files.
+* `./gradlew lintAll` runs Android lint plus Java Checkstyle checks.
+* `./gradlew qualityCheck` runs formatting checks and lint checks together.
+* `./gradlew testDebugUnitTest` runs the local JVM and Robolectric test suite.
+
 ## Screenshots
 
 ![](imgs/SS_bare_timer.png) ![](imgs/SS_navview.png)  ![](imgs/SS_counter.png)  ![](imgs/SS_Chooser.png)
 
-## License 
- 
+## License
+
 OneTwo is licensed under the MIT License
 
-<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="50"> 
+<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="50">
 <a href="https://play.google.com/store/apps/details?id=com.nicue.onetwo&hl=es_PR&gl=US"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" height="50"></a>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'checkstyle'
 
 android {
     compileSdk 35
@@ -26,7 +27,40 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
+    lint {
+        abortOnError true
+        checkDependencies true
+        htmlReport true
+        textReport true
+        xmlReport true
+    }
     namespace 'com.nicue.onetwo'
+}
+
+checkstyle {
+    toolVersion = '13.4.2'
+    configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+    ignoreFailures = false
+    showViolations = true
+}
+
+tasks.register('checkstyle', Checkstyle) {
+    group = 'verification'
+    description = 'Runs Checkstyle against Java source files.'
+    source 'src/main/java', 'src/test/java', 'src/androidTest/java'
+    include '**/*.java'
+    exclude '**/build/**'
+    classpath = files()
+
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.named('check') {
+    dependsOn rootProject.tasks.named('spotlessCheck')
+    dependsOn tasks.named('checkstyle')
 }
 
 dependencies {

--- a/app/src/androidTest/java/com/nicue/onetwo/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/nicue/onetwo/ExampleInstrumentedTest.java
@@ -1,19 +1,16 @@
 package com.nicue.onetwo;
 
+import static org.junit.Assert.assertEquals;
+
 import android.content.Context;
 import androidx.test.platform.app.InstrumentationRegistry;
-
 import org.junit.Test;
-
-
-import static org.junit.Assert.*;
 
 /**
  * Instrumentation test, which will execute on an Android device.
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
-
 public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() throws Exception {

--- a/app/src/main/java/com/nicue/onetwo/utils/Pools.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/Pools.java
@@ -2,6 +2,7 @@ package com.nicue.onetwo.utils;
 
 /**
  * Helper class for crating pools of objects. An example use looks like this:
+ *
  * <pre>
  * public class MyPooledClass {
  *
@@ -43,7 +44,6 @@ public final class Pools {
          *
          * @param instance The instance to release.
          * @return Whether the instance was put in the pool.
-         *
          * @throws IllegalStateException If the instance is already in the pool.
          */
         public boolean release(T instance);
@@ -67,7 +67,6 @@ public final class Pools {
          * Creates a new instance.
          *
          * @param maxPoolSize The max pool size.
-         *
          * @throws IllegalArgumentException If the max pool size is less than zero.
          */
         public SimplePool(int maxPoolSize) {
@@ -125,7 +124,6 @@ public final class Pools {
          * Creates a new instance.
          *
          * @param maxPoolSize The max pool size.
-         *
          * @throws IllegalArgumentException If the max pool size is less than zero.
          */
         public SynchronizedPool(int maxPoolSize) {

--- a/app/src/main/java/com/nicue/onetwo/utils/ScrollAwareFABBehavior.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/ScrollAwareFABBehavior.java
@@ -1,14 +1,12 @@
 package com.nicue.onetwo.utils;
 
-
 import android.content.Context;
-
-import androidx.annotation.NonNull;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ViewCompat;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class ScrollAwareFABBehavior extends FloatingActionButton.Behavior {
     public ScrollAwareFABBehavior(Context context, AttributeSet attrs) {
@@ -16,30 +14,46 @@ public class ScrollAwareFABBehavior extends FloatingActionButton.Behavior {
     }
 
     @Override
-    public boolean onStartNestedScroll(@NonNull CoordinatorLayout coordinatorLayout,
-                                       @NonNull FloatingActionButton child, @NonNull View directTargetChild, @NonNull View target, int nestedScrollAxes) {
-        return nestedScrollAxes == ViewCompat.SCROLL_AXIS_VERTICAL ||
-                super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target,
-                        nestedScrollAxes);
+    public boolean onStartNestedScroll(
+            @NonNull CoordinatorLayout coordinatorLayout,
+            @NonNull FloatingActionButton child,
+            @NonNull View directTargetChild,
+            @NonNull View target,
+            int nestedScrollAxes) {
+        return nestedScrollAxes == ViewCompat.SCROLL_AXIS_VERTICAL
+                || super.onStartNestedScroll(
+                        coordinatorLayout, child, directTargetChild, target, nestedScrollAxes);
     }
 
     @Override
-    public void onNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull FloatingActionButton child,
-                               @NonNull View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
-        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed,
+    public void onNestedScroll(
+            @NonNull CoordinatorLayout coordinatorLayout,
+            @NonNull FloatingActionButton child,
+            @NonNull View target,
+            int dxConsumed,
+            int dyConsumed,
+            int dxUnconsumed,
+            int dyUnconsumed) {
+        super.onNestedScroll(
+                coordinatorLayout,
+                child,
+                target,
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
                 dyUnconsumed);
 
         if (dyConsumed > 0 && child.getVisibility() == View.VISIBLE) {
-            child.hide(new FloatingActionButton.OnVisibilityChangedListener() {
-                @Override
-                public void onHidden(FloatingActionButton fab) {
-                    super.onShown(fab);
-                    fab.hide();
-                }
-            });
-        } else if (dyConsumed < 0){
+            child.hide(
+                    new FloatingActionButton.OnVisibilityChangedListener() {
+                        @Override
+                        public void onHidden(FloatingActionButton fab) {
+                            super.onShown(fab);
+                            fab.hide();
+                        }
+                    });
+        } else if (dyConsumed < 0) {
             child.show();
         }
     }
-
 }

--- a/app/src/test/java/com/nicue/onetwo/Utils/PoolsTest.java
+++ b/app/src/test/java/com/nicue/onetwo/Utils/PoolsTest.java
@@ -1,12 +1,12 @@
 package com.nicue.onetwo.utils;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 public class PoolsTest {
 

--- a/app/src/test/java/com/nicue/onetwo/Utils/TimerBackendTest.java
+++ b/app/src/test/java/com/nicue/onetwo/Utils/TimerBackendTest.java
@@ -1,8 +1,8 @@
 package com.nicue.onetwo.utils;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class TimerBackendTest {
 

--- a/app/src/test/java/com/nicue/onetwo/ui/counter/CounterFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/counter/CounterFragmentTest.java
@@ -1,20 +1,15 @@
 package com.nicue.onetwo.ui.counter;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import android.view.View;
-
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.fragment.app.testing.FragmentScenario;
-import androidx.lifecycle.Lifecycle;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.core.app.ApplicationProvider;
-
 import com.nicue.onetwo.OneTwoApplication;
 import com.nicue.onetwo.R;
 import com.nicue.onetwo.data.counter.CounterDatabase;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,23 +22,23 @@ import org.robolectric.annotation.Config;
 @Config(sdk = 34)
 public class CounterFragmentTest {
 
-    @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     private CounterDatabase testDb;
 
     @Before
     public void setUp() {
         OneTwoApplication app = ApplicationProvider.getApplicationContext();
-        
+
         // Create a test-friendly database that allows main thread queries
-        testDb = androidx.room.Room.inMemoryDatabaseBuilder(
-                app, CounterDatabase.class)
-                .allowMainThreadQueries()
-                .build();
-        
+        testDb =
+                androidx.room.Room.inMemoryDatabaseBuilder(app, CounterDatabase.class)
+                        .allowMainThreadQueries()
+                        .build();
+
         // Inject the test container with a synchronous executor
-        app.setAppContainerForTesting(new com.nicue.onetwo.core.AppContainer(app, testDb, Runnable::run));
+        app.setAppContainerForTesting(
+                new com.nicue.onetwo.core.AppContainer(app, testDb, Runnable::run));
     }
 
     @After
@@ -53,42 +48,53 @@ public class CounterFragmentTest {
 
     @Test
     public void launchFragment_showsEmptyStateInitially() {
-        FragmentScenario<CounterFragment> scenario = FragmentScenario.launchInContainer(CounterFragment.class, null, R.style.AppTheme);
-        
-        scenario.onFragment(fragment -> {
-            View instructionText = fragment.getView().findViewById(R.id.tv_instruction_counter);
-            assertEquals(View.VISIBLE, instructionText.getVisibility());
-            
-            RecyclerView recyclerView = fragment.getView().findViewById(R.id.recyclerview_counters);
-            assertEquals(0, recyclerView.getAdapter().getItemCount());
-        });
+        FragmentScenario<CounterFragment> scenario =
+                FragmentScenario.launchInContainer(CounterFragment.class, null, R.style.AppTheme);
+
+        scenario.onFragment(
+                fragment -> {
+                    View instructionText =
+                            fragment.getView().findViewById(R.id.tv_instruction_counter);
+                    assertEquals(View.VISIBLE, instructionText.getVisibility());
+
+                    RecyclerView recyclerView =
+                            fragment.getView().findViewById(R.id.recyclerview_counters);
+                    assertEquals(0, recyclerView.getAdapter().getItemCount());
+                });
     }
 
     @Test
     public void addCounterViaViewModel_updatesUI() {
-        FragmentScenario<CounterFragment> scenario = FragmentScenario.launchInContainer(CounterFragment.class, null, R.style.AppTheme);
+        FragmentScenario<CounterFragment> scenario =
+                FragmentScenario.launchInContainer(CounterFragment.class, null, R.style.AppTheme);
 
-        scenario.onFragment(fragment -> {
-            // Simulate adding a counter directly to the ViewModel
-            // which the Fragment is observing
-            CounterViewModel viewModel = new androidx.lifecycle.ViewModelProvider(fragment).get(CounterViewModel.class);
-            viewModel.addCounter("Test Player", 10);
-            
-            // Note: Since we use an Executor in the Repository, 
-            // we might need to ensure the work is finished.
-            // In your existing tests, you use a direct executor.
-        });
+        scenario.onFragment(
+                fragment -> {
+                    // Simulate adding a counter directly to the ViewModel
+                    // which the Fragment is observing
+                    CounterViewModel viewModel =
+                            new androidx.lifecycle.ViewModelProvider(fragment)
+                                    .get(CounterViewModel.class);
+                    viewModel.addCounter("Test Player", 10);
+
+                    // Note: Since we use an Executor in the Repository,
+                    // we might need to ensure the work is finished.
+                    // In your existing tests, you use a direct executor.
+                });
 
         // Re-check UI state
-        scenario.onFragment(fragment -> {
-            RecyclerView recyclerView = fragment.getView().findViewById(R.id.recyclerview_counters);
-            
-            // Robolectric + LiveData + Room (in-memory) usually syncs fast
-            // but in a production test, you might use a "Shadow" or "IdlingResource"
-            assertEquals(1, recyclerView.getAdapter().getItemCount());
-            
-            View instructionText = fragment.getView().findViewById(R.id.tv_instruction_counter);
-            assertEquals(View.INVISIBLE, instructionText.getVisibility());
-        });
+        scenario.onFragment(
+                fragment -> {
+                    RecyclerView recyclerView =
+                            fragment.getView().findViewById(R.id.recyclerview_counters);
+
+                    // Robolectric + LiveData + Room (in-memory) usually syncs fast
+                    // but in a production test, you might use a "Shadow" or "IdlingResource"
+                    assertEquals(1, recyclerView.getAdapter().getItemCount());
+
+                    View instructionText =
+                            fragment.getView().findViewById(R.id.tv_instruction_counter);
+                    assertEquals(View.INVISIBLE, instructionText.getVisibility());
+                });
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,18 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:9.2.1'
+        classpath 'com.diffplug.spotless:spotless-plugin-gradle:7.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
+
+apply plugin: 'com.diffplug.spotless'
 
 allprojects {
     repositories {
@@ -20,6 +24,49 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+spotless {
+    ratchetFrom 'origin/master'
+
+    java {
+        target 'app/src/**/*.java'
+        googleJavaFormat('1.28.0').aosp()
+        removeUnusedImports()
+        formatAnnotations()
+    }
+
+    format 'projectFiles', {
+        target '**/*.gradle', '**/*.md', '**/*.properties', '**/*.xml'
+        targetExclude '**/build/**', '.gradle/**', '.idea/**', 'local.properties'
+        leadingTabsToSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+tasks.register('format') {
+    group = 'formatting'
+    description = 'Formats Java and project resource files.'
+    dependsOn 'spotlessApply'
+}
+
+tasks.register('formatCheck') {
+    group = 'verification'
+    description = 'Checks Java and project resource file formatting.'
+    dependsOn 'spotlessCheck'
+}
+
+tasks.register('lintAll') {
+    group = 'verification'
+    description = 'Runs Android lint and Java style checks.'
+    dependsOn ':app:lintDebug', ':app:checkstyle'
+}
+
+tasks.register('qualityCheck') {
+    group = 'verification'
+    description = 'Runs formatter checks, Android lint, and Java style checks.'
+    dependsOn 'formatCheck', 'lintAll'
+}
+
+tasks.named('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <module name="FileTabCharacter"/>
+    <module name="NewlineAtEndOfFile"/>
+
+    <module name="TreeWalker">
+        <module name="AvoidStarImport"/>
+        <module name="OuterTypeFilename"/>
+        <module name="UnusedImports"/>
+    </module>
+</module>


### PR DESCRIPTION
## Summary
- Add Spotless-based formatting tasks for Java and project files, plus `format`, `formatCheck`, `lintAll`, and `qualityCheck` Gradle entry points.
- Add Checkstyle with a small ruleset for imports, tabs, and final newlines.
- Wire Android lint reporting into the app module and document the new developer commands in the README.
- Clean up a few existing style violations so the new checks pass.

## Testing
- `./gradlew formatCheck lintAll` passed.
- `./gradlew testDebugUnitTest` passed.
- `git diff --check` passed.