### PR TITLE
Make counter rows draggable and persist order

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 22
-        versionName "1.5.0"
+        versionCode 23
+        versionName "1.6.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/core/AppContainer.java
+++ b/app/src/main/java/com/nicue/onetwo/core/AppContainer.java
@@ -1,9 +1,7 @@
 package com.nicue.onetwo.core;
 
 import android.app.Application;
-
 import androidx.room.Room;
-
 import com.nicue.onetwo.data.counter.CounterDatabase;
 import com.nicue.onetwo.data.counter.CounterRepository;
 import com.nicue.onetwo.data.dice.DicePrefsDataSource;
@@ -12,7 +10,6 @@ import com.nicue.onetwo.data.settings.SettingsPrefsDataSource;
 import com.nicue.onetwo.data.settings.SettingsRepository;
 import com.nicue.onetwo.data.timer.TimerStateStore;
 import com.nicue.onetwo.db.TaskContract;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -23,21 +20,22 @@ public class AppContainer {
     private final TimerStateStore timerStateStore;
 
     public AppContainer(Application application) {
-        this(application,
+        this(
+                application,
                 Room.databaseBuilder(application, CounterDatabase.class, TaskContract.DB_NAME)
                         .addMigrations(CounterDatabase.MIGRATION_2_3)
                         .build(),
                 Executors.newSingleThreadExecutor());
     }
 
-    public AppContainer(Application application, CounterDatabase counterDatabase, Executor executor) {
+    public AppContainer(
+            Application application, CounterDatabase counterDatabase, Executor executor) {
         this.counterRepository = new CounterRepository(counterDatabase.counterDao(), executor);
-        this.diceRepository = new DiceRepository(
-                new DicePrefsDataSource(application.getApplicationContext())
-        );
-        this.settingsRepository = new SettingsRepository(
-                new SettingsPrefsDataSource(application.getApplicationContext())
-        );
+        this.diceRepository =
+                new DiceRepository(new DicePrefsDataSource(application.getApplicationContext()));
+        this.settingsRepository =
+                new SettingsRepository(
+                        new SettingsPrefsDataSource(application.getApplicationContext()));
         this.timerStateStore = new TimerStateStore();
     }
 

--- a/app/src/main/java/com/nicue/onetwo/core/AppContainer.java
+++ b/app/src/main/java/com/nicue/onetwo/core/AppContainer.java
@@ -23,11 +23,11 @@ public class AppContainer {
     private final TimerStateStore timerStateStore;
 
     public AppContainer(Application application) {
-        this(application, Room.databaseBuilder(
-                application,
-                CounterDatabase.class,
-                TaskContract.DB_NAME
-        ).build(), Executors.newSingleThreadExecutor());
+        this(application,
+                Room.databaseBuilder(application, CounterDatabase.class, TaskContract.DB_NAME)
+                        .addMigrations(CounterDatabase.MIGRATION_2_3)
+                        .build(),
+                Executors.newSingleThreadExecutor());
     }
 
     public AppContainer(Application application, CounterDatabase counterDatabase, Executor executor) {

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterDao.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterDao.java
@@ -4,19 +4,33 @@ import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Query;
+import androidx.room.Transaction;
 
 import java.util.List;
 
 @Dao
 public interface CounterDao {
-    @Query("SELECT * FROM Objects ORDER BY _id ASC")
+    @Query("SELECT * FROM Objects ORDER BY sort_order ASC, _id ASC")
     LiveData<List<CounterEntity>> observeCounters();
+
+    @Query("SELECT COALESCE(MAX(sort_order), -1) + 1 FROM Objects")
+    int getNextSortOrder();
 
     @Insert
     void insert(CounterEntity counterEntity);
 
     @Query("UPDATE Objects SET numbers = :value WHERE _id = :counterId")
     void updateValue(long counterId, int value);
+
+    @Query("UPDATE Objects SET sort_order = :sortOrder WHERE _id = :counterId")
+    void updateSortOrder(long counterId, int sortOrder);
+
+    @Transaction
+    default void updateSortOrders(List<Long> orderedCounterIds) {
+        for (int i = 0; i < orderedCounterIds.size(); i++) {
+            updateSortOrder(orderedCounterIds.get(i), i);
+        }
+    }
 
     @Query("DELETE FROM Objects WHERE _id = :counterId")
     void deleteById(long counterId);

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterDao.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterDao.java
@@ -5,7 +5,6 @@ import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Query;
 import androidx.room.Transaction;
-
 import java.util.List;
 
 @Dao

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterDatabase.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterDatabase.java
@@ -2,8 +2,20 @@ package com.nicue.onetwo.data.counter;
 
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {CounterEntity.class}, version = 2, exportSchema = false)
+@Database(entities = {CounterEntity.class}, version = 3, exportSchema = false)
 public abstract class CounterDatabase extends RoomDatabase {
+    public static final Migration MIGRATION_2_3 =
+            new Migration(2, 3) {
+                @Override
+                public void migrate(SupportSQLiteDatabase database) {
+                    database.execSQL(
+                            "ALTER TABLE Objects ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0");
+                    database.execSQL("UPDATE Objects SET sort_order = _id - 1");
+                }
+            };
+
     public abstract CounterDao counterDao();
 }

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterDatabase.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterDatabase.java
@@ -5,7 +5,10 @@ import androidx.room.RoomDatabase;
 import androidx.room.migration.Migration;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {CounterEntity.class}, version = 3, exportSchema = false)
+@Database(
+        entities = {CounterEntity.class},
+        version = 3,
+        exportSchema = false)
 public abstract class CounterDatabase extends RoomDatabase {
     public static final Migration MIGRATION_2_3 =
             new Migration(2, 3) {

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterEntity.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterEntity.java
@@ -16,6 +16,9 @@ public class CounterEntity {
     @ColumnInfo(name = "numbers")
     private int value;
 
+    @ColumnInfo(name = "sort_order")
+    private int sortOrder;
+
     public CounterEntity(String title, int value) {
         this.title = title;
         this.value = value;
@@ -35,5 +38,13 @@ public class CounterEntity {
 
     public int getValue() {
         return value;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterRepository.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterRepository.java
@@ -1,7 +1,6 @@
 package com.nicue.onetwo.data.counter;
 
 import androidx.lifecycle.LiveData;
-
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -19,40 +18,44 @@ public class CounterRepository {
     }
 
     public void addCounter(String title, int value) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                CounterEntity counterEntity = new CounterEntity(title, value);
-                counterEntity.setSortOrder(counterDao.getNextSortOrder());
-                counterDao.insert(counterEntity);
-            }
-        });
+        executor.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        CounterEntity counterEntity = new CounterEntity(title, value);
+                        counterEntity.setSortOrder(counterDao.getNextSortOrder());
+                        counterDao.insert(counterEntity);
+                    }
+                });
     }
 
     public void updateCounterValue(long counterId, int value) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                counterDao.updateValue(counterId, value);
-            }
-        });
+        executor.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        counterDao.updateValue(counterId, value);
+                    }
+                });
     }
 
     public void deleteCounter(long counterId) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                counterDao.deleteById(counterId);
-            }
-        });
+        executor.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        counterDao.deleteById(counterId);
+                    }
+                });
     }
 
     public void reorderCounters(final List<Long> orderedCounterIds) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                counterDao.updateSortOrders(orderedCounterIds);
-            }
-        });
+        executor.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        counterDao.updateSortOrders(orderedCounterIds);
+                    }
+                });
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/data/counter/CounterRepository.java
+++ b/app/src/main/java/com/nicue/onetwo/data/counter/CounterRepository.java
@@ -22,7 +22,9 @@ public class CounterRepository {
         executor.execute(new Runnable() {
             @Override
             public void run() {
-                counterDao.insert(new CounterEntity(title, value));
+                CounterEntity counterEntity = new CounterEntity(title, value);
+                counterEntity.setSortOrder(counterDao.getNextSortOrder());
+                counterDao.insert(counterEntity);
             }
         });
     }
@@ -41,6 +43,15 @@ public class CounterRepository {
             @Override
             public void run() {
                 counterDao.deleteById(counterId);
+            }
+        });
+    }
+
+    public void reorderCounters(final List<Long> orderedCounterIds) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                counterDao.updateSortOrders(orderedCounterIds);
             }
         });
     }

--- a/app/src/main/java/com/nicue/onetwo/db/TaskContract.java
+++ b/app/src/main/java/com/nicue/onetwo/db/TaskContract.java
@@ -5,7 +5,7 @@ import android.provider.BaseColumns;
 
 public class TaskContract {
     public static final String DB_NAME = "com.nicue.onetwo.db";
-    public static final int DB_VERSION = 2;
+    public static final int DB_VERSION = 3;
 
     public static class TaskEntry implements BaseColumns {
         public static final String TABLE = "Objects";
@@ -13,6 +13,8 @@ public class TaskContract {
         public static final String COL_TASK_TITLE = "title";
 
         public static final String COL_NUM_TITLE = "numbers";
+
+        public static final String COL_SORT_ORDER = "sort_order";
 
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/db/TaskContract.java
+++ b/app/src/main/java/com/nicue/onetwo/db/TaskContract.java
@@ -1,6 +1,5 @@
 package com.nicue.onetwo.db;
 
-
 import android.provider.BaseColumns;
 
 public class TaskContract {
@@ -15,6 +14,5 @@ public class TaskContract {
         public static final String COL_NUM_TITLE = "numbers";
 
         public static final String COL_SORT_ORDER = "sort_order";
-
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/counter/CounterFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/counter/CounterFragment.java
@@ -16,7 +16,9 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
@@ -32,6 +34,8 @@ public class CounterFragment extends Fragment implements CounterListAdapter.List
     private CounterLayoutBinding binding;
     private CounterListAdapter adapter;
     private CounterViewModel viewModel;
+    private ItemTouchHelper itemTouchHelper;
+    private boolean counterOrderChanged;
     private int lastCounterCount = -1;
 
     @Nullable @Override
@@ -56,6 +60,44 @@ public class CounterFragment extends Fragment implements CounterListAdapter.List
                 new DividerItemDecoration(
                         binding.recyclerviewCounters.getContext(), layoutManager.getOrientation()));
         binding.recyclerviewCounters.setAdapter(adapter);
+        itemTouchHelper =
+                new ItemTouchHelper(
+                        new ItemTouchHelper.SimpleCallback(
+                                ItemTouchHelper.UP | ItemTouchHelper.DOWN, 0) {
+                            @Override
+                            public boolean isLongPressDragEnabled() {
+                                return false;
+                            }
+
+                            @Override
+                            public boolean onMove(
+                                    @NonNull RecyclerView recyclerView,
+                                    @NonNull RecyclerView.ViewHolder viewHolder,
+                                    @NonNull RecyclerView.ViewHolder target) {
+                                boolean moved =
+                                        adapter.moveItem(
+                                                viewHolder.getAdapterPosition(),
+                                                target.getAdapterPosition());
+                                counterOrderChanged = counterOrderChanged || moved;
+                                return moved;
+                            }
+
+                            @Override
+                            public void onSwiped(
+                                    @NonNull RecyclerView.ViewHolder viewHolder, int direction) {}
+
+                            @Override
+                            public void clearView(
+                                    @NonNull RecyclerView recyclerView,
+                                    @NonNull RecyclerView.ViewHolder viewHolder) {
+                                super.clearView(recyclerView, viewHolder);
+                                if (counterOrderChanged) {
+                                    viewModel.reorderCounters(adapter.getCounterIds());
+                                    counterOrderChanged = false;
+                                }
+                            }
+                        });
+        itemTouchHelper.attachToRecyclerView(binding.recyclerviewCounters);
 
         binding.fab.setScaleX(0f);
         binding.fab.setScaleY(0f);
@@ -122,6 +164,8 @@ public class CounterFragment extends Fragment implements CounterListAdapter.List
     @Override
     public void onDestroyView() {
         binding = null;
+        itemTouchHelper = null;
+        counterOrderChanged = false;
         super.onDestroyView();
     }
 
@@ -138,6 +182,13 @@ public class CounterFragment extends Fragment implements CounterListAdapter.List
     @Override
     public void onDeleteClicked(long counterId) {
         viewModel.deleteCounter(counterId);
+    }
+
+    @Override
+    public void onDragHandleTouched(RecyclerView.ViewHolder viewHolder) {
+        if (itemTouchHelper != null) {
+            itemTouchHelper.startDrag(viewHolder);
+        }
     }
 
     public static String sanitizeObjectName(String name) {

--- a/app/src/main/java/com/nicue/onetwo/ui/counter/CounterListAdapter.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/counter/CounterListAdapter.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.NumberPicker;
 import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 import com.nicue.onetwo.data.counter.CounterEntity;
 import com.nicue.onetwo.databinding.ListItemBinding;
@@ -48,9 +49,12 @@ public class CounterListAdapter extends RecyclerView.Adapter<CounterListAdapter.
         return counters.size();
     }
 
-    public void submitList(List<CounterEntity> counters) {
-        this.counters = counters == null ? new ArrayList<CounterEntity>() : counters;
-        notifyDataSetChanged();
+    public void submitList(List<CounterEntity> newCounters) {
+        if (newCounters == null) newCounters = new ArrayList<>();
+        DiffUtil.DiffResult diffResult =
+                DiffUtil.calculateDiff(new CounterDiffCallback(this.counters, newCounters));
+        this.counters = new ArrayList<>(newCounters);
+        diffResult.dispatchUpdatesTo(this);
     }
 
     public boolean moveItem(int fromPosition, int toPosition) {
@@ -219,6 +223,40 @@ public class CounterListAdapter extends RecyclerView.Adapter<CounterListAdapter.
                 default:
                     return false;
             }
+        }
+    }
+
+    private static class CounterDiffCallback extends DiffUtil.Callback {
+        private final List<CounterEntity> oldList;
+        private final List<CounterEntity> newList;
+
+        CounterDiffCallback(List<CounterEntity> oldList, List<CounterEntity> newList) {
+            this.oldList = oldList;
+            this.newList = newList;
+        }
+
+        @Override
+        public int getOldListSize() {
+            return oldList.size();
+        }
+
+        @Override
+        public int getNewListSize() {
+            return newList.size();
+        }
+
+        @Override
+        public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+            return oldList.get(oldItemPosition).getId() == newList.get(newItemPosition).getId();
+        }
+
+        @Override
+        public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+            CounterEntity oldItem = oldList.get(oldItemPosition);
+            CounterEntity newItem = newList.get(newItemPosition);
+            return oldItem.getValue() == newItem.getValue()
+                    && oldItem.getTitle().equals(newItem.getTitle())
+                    && oldItem.getSortOrder() == newItem.getSortOrder();
         }
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/counter/CounterListAdapter.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/counter/CounterListAdapter.java
@@ -21,6 +21,8 @@ public class CounterListAdapter extends RecyclerView.Adapter<CounterListAdapter.
         void onAdjustmentClicked(long counterId, int currentValue, boolean add);
 
         void onDeleteClicked(long counterId);
+
+        void onDragHandleTouched(RecyclerView.ViewHolder viewHolder);
     }
 
     private final Listener listener;
@@ -51,6 +53,27 @@ public class CounterListAdapter extends RecyclerView.Adapter<CounterListAdapter.
         notifyDataSetChanged();
     }
 
+    public boolean moveItem(int fromPosition, int toPosition) {
+        if (fromPosition < 0
+                || toPosition < 0
+                || fromPosition >= counters.size()
+                || toPosition >= counters.size()) {
+            return false;
+        }
+        CounterEntity movedCounter = counters.remove(fromPosition);
+        counters.add(toPosition, movedCounter);
+        notifyItemMoved(fromPosition, toPosition);
+        return true;
+    }
+
+    public List<Long> getCounterIds() {
+        List<Long> counterIds = new ArrayList<>();
+        for (CounterEntity counter : counters) {
+            counterIds.add(counter.getId());
+        }
+        return counterIds;
+    }
+
     class CounterViewHolder extends RecyclerView.ViewHolder
             implements NumberPicker.OnValueChangeListener, NumberPicker.OnScrollListener {
         private final ListItemBinding binding;
@@ -76,6 +99,17 @@ public class CounterListAdapter extends RecyclerView.Adapter<CounterListAdapter.
                         public boolean onLongClick(View v) {
                             v.performClick();
                             return true;
+                        }
+                    });
+            binding.gripDots.setOnTouchListener(
+                    new View.OnTouchListener() {
+                        @Override
+                        public boolean onTouch(View v, MotionEvent event) {
+                            if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
+                                listener.onDragHandleTouched(CounterViewHolder.this);
+                                return true;
+                            }
+                            return false;
                         }
                     });
             binding.removeButton.setOnClickListener(

--- a/app/src/main/java/com/nicue/onetwo/ui/counter/CounterViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/counter/CounterViewModel.java
@@ -2,10 +2,8 @@ package com.nicue.onetwo.ui.counter;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModel;
-
 import com.nicue.onetwo.data.counter.CounterEntity;
 import com.nicue.onetwo.data.counter.CounterRepository;
-
 import java.util.List;
 
 public class CounterViewModel extends ViewModel {

--- a/app/src/main/java/com/nicue/onetwo/ui/counter/CounterViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/counter/CounterViewModel.java
@@ -32,4 +32,8 @@ public class CounterViewModel extends ViewModel {
     public void deleteCounter(long counterId) {
         counterRepository.deleteCounter(counterId);
     }
+
+    public void reorderCounters(List<Long> orderedCounterIds) {
+        counterRepository.reorderCounters(orderedCounterIds);
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/data/counter/CounterRepositoryTest.java
+++ b/app/src/test/java/com/nicue/onetwo/data/counter/CounterRepositoryTest.java
@@ -3,13 +3,13 @@ package com.nicue.onetwo.data.counter;
 import static org.junit.Assert.assertEquals;
 
 import android.content.Context;
-
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
 import androidx.test.core.app.ApplicationProvider;
-
 import com.nicue.onetwo.LiveDataTestUtil;
-
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -18,15 +18,10 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Executor;
-
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
 public class CounterRepositoryTest {
-    @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     private CounterDatabase counterDatabase;
     private CounterRepository counterRepository;
@@ -34,15 +29,17 @@ public class CounterRepositoryTest {
     @Before
     public void setUp() {
         Context context = ApplicationProvider.getApplicationContext();
-        counterDatabase = Room.inMemoryDatabaseBuilder(context, CounterDatabase.class)
-                .allowMainThreadQueries()
-                .build();
-        Executor directExecutor = new Executor() {
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        };
+        counterDatabase =
+                Room.inMemoryDatabaseBuilder(context, CounterDatabase.class)
+                        .allowMainThreadQueries()
+                        .build();
+        Executor directExecutor =
+                new Executor() {
+                    @Override
+                    public void execute(Runnable command) {
+                        command.run();
+                    }
+                };
         counterRepository = new CounterRepository(counterDatabase.counterDao(), directExecutor);
     }
 
@@ -83,9 +80,7 @@ public class CounterRepositoryTest {
 
         counterRepository.reorderCounters(
                 Arrays.asList(
-                        counters.get(2).getId(),
-                        counters.get(0).getId(),
-                        counters.get(1).getId()));
+                        counters.get(2).getId(), counters.get(0).getId(), counters.get(1).getId()));
 
         counters = LiveDataTestUtil.getValue(counterRepository.observeCounters());
         assertEquals("Gamma", counters.get(0).getTitle());

--- a/app/src/test/java/com/nicue/onetwo/data/counter/CounterRepositoryTest.java
+++ b/app/src/test/java/com/nicue/onetwo/data/counter/CounterRepositoryTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -55,7 +56,8 @@ public class CounterRepositoryTest {
         counterRepository.addCounter("Alpha", 3);
         counterRepository.addCounter("Beta", 7);
 
-        List<CounterEntity> counters = LiveDataTestUtil.getValue(counterRepository.observeCounters());
+        List<CounterEntity> counters =
+                LiveDataTestUtil.getValue(counterRepository.observeCounters());
         assertEquals(2, counters.size());
         assertEquals("Alpha", counters.get(0).getTitle());
         assertEquals(3, counters.get(0).getValue());
@@ -68,5 +70,26 @@ public class CounterRepositoryTest {
         counters = LiveDataTestUtil.getValue(counterRepository.observeCounters());
         assertEquals(1, counters.size());
         assertEquals("Alpha", counters.get(0).getTitle());
+    }
+
+    @Test
+    public void reorderCounters_updatesObservedOrder() throws Exception {
+        counterRepository.addCounter("Alpha", 1);
+        counterRepository.addCounter("Beta", 2);
+        counterRepository.addCounter("Gamma", 3);
+
+        List<CounterEntity> counters =
+                LiveDataTestUtil.getValue(counterRepository.observeCounters());
+
+        counterRepository.reorderCounters(
+                Arrays.asList(
+                        counters.get(2).getId(),
+                        counters.get(0).getId(),
+                        counters.get(1).getId()));
+
+        counters = LiveDataTestUtil.getValue(counterRepository.observeCounters());
+        assertEquals("Gamma", counters.get(0).getTitle());
+        assertEquals("Alpha", counters.get(1).getTitle());
+        assertEquals("Beta", counters.get(2).getTitle());
     }
 }


### PR DESCRIPTION
## Summary
- Added drag-and-drop reordering for counter rows using the new grip icon in the counter list.
- Persisted row order in Room with a new `sort_order` column, migration, and DAO/repository updates.
- Kept existing swipe-to-delete and counter value behavior intact.
- Added a repository test to verify reordered rows are returned in the saved order.

## Testing
- `./gradlew testDebugUnitTest`