### PR TITLE
Add MTG life counter fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 24
-        versionName "1.6.1"
+        versionCode 25
+        versionName "1.7.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 25
-        versionName "1.7.0"
+        versionCode 26
+        versionName "1.7.1"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/MainActivity.java
+++ b/app/src/main/java/com/nicue/onetwo/MainActivity.java
@@ -2,14 +2,12 @@ package com.nicue.onetwo;
 
 import android.os.Bundle;
 import android.view.WindowManager;
-
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
-
 import com.nicue.onetwo.core.AppContainer;
 import com.nicue.onetwo.data.settings.SettingsRepository;
 import com.nicue.onetwo.databinding.ActivityMainBinding;
@@ -32,20 +30,23 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
 
         settingsRepository.applyKeepScreenOn(getWindow());
 
-        NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager()
-                .findFragmentById(R.id.nav_host_fragment);
+        NavHostFragment navHostFragment =
+                (NavHostFragment)
+                        getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment);
         if (navHostFragment == null) {
             throw new IllegalStateException("NavHostFragment is missing from activity_main");
         }
         NavController navController = navHostFragment.getNavController();
-        appBarConfiguration = new AppBarConfiguration.Builder(
-                R.id.nav_counter,
-                R.id.nav_dice,
-                R.id.nav_chooser,
-                R.id.nav_timer,
-                R.id.nav_mtg_life,
-                R.id.nav_settings
-        ).setOpenableLayout(binding.drawerLayout).build();
+        appBarConfiguration =
+                new AppBarConfiguration.Builder(
+                                R.id.nav_counter,
+                                R.id.nav_dice,
+                                R.id.nav_chooser,
+                                R.id.nav_timer,
+                                R.id.nav_mtg_life,
+                                R.id.nav_settings)
+                        .setOpenableLayout(binding.drawerLayout)
+                        .build();
 
         NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
         NavigationUI.setupWithNavController(binding.nvView, navController);
@@ -53,8 +54,9 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
 
     @Override
     public boolean onSupportNavigateUp() {
-        NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager()
-                .findFragmentById(R.id.nav_host_fragment);
+        NavHostFragment navHostFragment =
+                (NavHostFragment)
+                        getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment);
         if (navHostFragment == null) {
             return super.onSupportNavigateUp();
         }
@@ -77,8 +79,7 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
         AppCompatDelegate.setDefaultNightMode(
                 darkModeEnabled
                         ? AppCompatDelegate.MODE_NIGHT_YES
-                        : AppCompatDelegate.MODE_NIGHT_NO
-        );
+                        : AppCompatDelegate.MODE_NIGHT_NO);
     }
 
     private AppContainer getAppContainer() {

--- a/app/src/main/java/com/nicue/onetwo/MainActivity.java
+++ b/app/src/main/java/com/nicue/onetwo/MainActivity.java
@@ -43,6 +43,7 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
                 R.id.nav_dice,
                 R.id.nav_chooser,
                 R.id.nav_timer,
+                R.id.nav_mtg_life,
                 R.id.nav_settings
         ).setOpenableLayout(binding.drawerLayout).build();
 

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -7,7 +7,12 @@ public class LifePlayerUiModel {
     private final int backgroundColorRes;
     private final int foregroundColorRes;
 
-    public LifePlayerUiModel(int seatIndex, int lifeTotal, int rotationDegrees, int backgroundColorRes, int foregroundColorRes) {
+    public LifePlayerUiModel(
+            int seatIndex,
+            int lifeTotal,
+            int rotationDegrees,
+            int backgroundColorRes,
+            int foregroundColorRes) {
         this.seatIndex = seatIndex;
         this.lifeTotal = lifeTotal;
         this.rotationDegrees = rotationDegrees;
@@ -35,4 +40,3 @@ public class LifePlayerUiModel {
         return foregroundColorRes;
     }
 }
-

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -1,0 +1,37 @@
+package com.nicue.onetwo.ui.life;
+
+public class LifePlayerUiModel {
+    private final int seatIndex;
+    private final int lifeTotal;
+    private final int rotationDegrees;
+    private final int backgroundColorRes;
+    private final int foregroundColorRes;
+
+    public LifePlayerUiModel(int seatIndex, int lifeTotal, int rotationDegrees, int backgroundColorRes, int foregroundColorRes) {
+        this.seatIndex = seatIndex;
+        this.lifeTotal = lifeTotal;
+        this.rotationDegrees = rotationDegrees;
+        this.backgroundColorRes = backgroundColorRes;
+        this.foregroundColorRes = foregroundColorRes;
+    }
+
+    public int getSeatIndex() {
+        return seatIndex;
+    }
+
+    public int getLifeTotal() {
+        return lifeTotal;
+    }
+
+    public int getRotationDegrees() {
+        return rotationDegrees;
+    }
+
+    public int getBackgroundColorRes() {
+        return backgroundColorRes;
+    }
+
+    public int getForegroundColorRes() {
+        return foregroundColorRes;
+    }
+}

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -35,3 +35,4 @@ public class LifePlayerUiModel {
         return foregroundColorRes;
     }
 }
+

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -131,18 +131,42 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         cellBinding.playerCellContainer.setBackgroundColor(bgColor);
                         cellBinding.tvLifeCount.setTextColor(fgColor);
 
+                        float rotation = player.getRotationDegrees();
+                        cellBinding.playerCellContainer.setRotation(0f);
+                        cellBinding.tvLifeCount.setRotation(rotation);
+
+                        final int seatIndex = player.getSeatIndex();
+
+                        // btn_plus is physically at the top, btn_minus is physically at the bottom.
+                        boolean topIsPlus = (rotation == 0f || rotation == 270f);
+
+                        if (topIsPlus) {
+                            // Top button acts as PLUS
+                            cellBinding.btnPlus.setIconResource(R.drawable.ic_add_24);
+                            cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+                            cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+
+                            // Bottom button acts as MINUS
+                            cellBinding.btnMinus.setIconResource(R.drawable.ic_remove_24);
+                            cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
+                            cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
+                        } else {
+                            // Top button acts as MINUS
+                            cellBinding.btnPlus.setIconResource(R.drawable.ic_remove_24);
+                            cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
+                            cellBinding.btnPlus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
+
+                            // Bottom button acts as PLUS
+                            cellBinding.btnMinus.setIconResource(R.drawable.ic_add_24);
+                            cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+                            cellBinding.btnMinus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+                        }
+
                         cellBinding.btnMinus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
                         cellBinding.btnPlus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
 
-                        float rotation = player.getRotationDegrees();
-                        cellBinding.playerCellContainer.setRotation(rotation);
-
-                        final int seatIndex = player.getSeatIndex();
-                        cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
-                        cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
-
-                        cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
-                        cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+                        cellBinding.btnMinus.setRotation(rotation);
+                        cellBinding.btnPlus.setRotation(rotation);
                     }
                 }
             }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.core.view.MenuHost;
 import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
@@ -191,11 +192,13 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                                 String.valueOf(player.getLifeTotal()));
 
                                         int bgColor =
-                                                requireContext()
-                                                        .getColor(player.getBackgroundColorRes());
+                                                ContextCompat.getColor(
+                                                        requireContext(),
+                                                        player.getBackgroundColorRes());
                                         int fgColor =
-                                                requireContext()
-                                                        .getColor(player.getForegroundColorRes());
+                                                ContextCompat.getColor(
+                                                        requireContext(),
+                                                        player.getForegroundColorRes());
 
                                         cellBinding.playerCellContainer.setBackgroundColor(bgColor);
                                         cellBinding.tvLifeCount.setTextColor(fgColor);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -18,6 +18,7 @@ public class MtgLifeFragment extends Fragment {
 
     private LifeFragmentBinding binding;
     private MtgLifeViewModel viewModel;
+    private boolean inputsInitialized = false;
 
     @Nullable
     @Override
@@ -39,50 +40,34 @@ public class MtgLifeFragment extends Fragment {
                 binding.setupContent.getRoot().setVisibility(View.VISIBLE);
                 binding.boardContainer.setVisibility(View.GONE);
                 
-                setupBinding.playersInput.setText(String.valueOf(uiState.getPlayerCount()));
-                setupBinding.lifeInput.setText(String.valueOf(uiState.getStartingLife()));
-                setupBinding.playersInputLayout.setError(null);
-                setupBinding.lifeInputLayout.setError(null);
+                if (!inputsInitialized) {
+                    setupBinding.playersInput.setText(String.valueOf(uiState.getPlayerCount()));
+                    setupBinding.lifeInput.setText(String.valueOf(uiState.getStartingLife()));
+                    inputsInitialized = true;
+                }
+
+                if (uiState.getPlayersErrorResId() != null) {
+                    setupBinding.playersInputLayout.setError(getString(uiState.getPlayersErrorResId()));
+                } else {
+                    setupBinding.playersInputLayout.setError(null);
+                }
+
+                if (uiState.getLifeErrorResId() != null) {
+                    setupBinding.lifeInputLayout.setError(getString(uiState.getLifeErrorResId()));
+                } else {
+                    setupBinding.lifeInputLayout.setError(null);
+                }
             } else {
                 binding.setupContent.getRoot().setVisibility(View.GONE);
                 binding.boardContainer.setVisibility(View.VISIBLE);
+                inputsInitialized = false;
             }
         });
 
         setupBinding.startGameButton.setOnClickListener(v -> {
             String playersStr = setupBinding.playersInput.getText().toString();
             String lifeStr = setupBinding.lifeInput.getText().toString();
-            
-            boolean valid = true;
-            try {
-                int players = Integer.parseInt(playersStr);
-                if (players < 1 || players > 6) {
-                    setupBinding.playersInputLayout.setError(getString(R.string.mtg_setup_players_error));
-                    valid = false;
-                } else {
-                    setupBinding.playersInputLayout.setError(null);
-                }
-            } catch (NumberFormatException e) {
-                setupBinding.playersInputLayout.setError(getString(R.string.mtg_setup_players_error));
-                valid = false;
-            }
-
-            try {
-                int life = Integer.parseInt(lifeStr);
-                if (life <= 0) {
-                    setupBinding.lifeInputLayout.setError(getString(R.string.mtg_setup_life_error));
-                    valid = false;
-                } else {
-                    setupBinding.lifeInputLayout.setError(null);
-                }
-            } catch (NumberFormatException e) {
-                setupBinding.lifeInputLayout.setError(getString(R.string.mtg_setup_life_error));
-                valid = false;
-            }
-
-            if (valid) {
-                viewModel.validateAndStartGame(playersStr, lifeStr);
-            }
+            viewModel.validateAndStartGame(playersStr, lifeStr);
         });
     }
 

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -13,12 +13,20 @@ import androidx.lifecycle.ViewModelProvider;
 import com.nicue.onetwo.R;
 import com.nicue.onetwo.databinding.LifeFragmentBinding;
 import com.nicue.onetwo.databinding.LifeSetupContentBinding;
+import com.nicue.onetwo.databinding.LifeBoard1Binding;
+import com.nicue.onetwo.databinding.LifeBoard2Binding;
+import com.nicue.onetwo.databinding.LifeBoard3Binding;
+import com.nicue.onetwo.databinding.LifeBoard4Binding;
+import com.nicue.onetwo.databinding.LifeBoard5Binding;
+import com.nicue.onetwo.databinding.LifeBoard6Binding;
+import com.nicue.onetwo.databinding.LifePlayerCellBinding;
 
 public class MtgLifeFragment extends Fragment {
 
     private LifeFragmentBinding binding;
     private MtgLifeViewModel viewModel;
     private boolean inputsInitialized = false;
+    private int currentBoardPlayerCount = -1;
 
     @Nullable
     @Override
@@ -61,6 +69,75 @@ public class MtgLifeFragment extends Fragment {
                 binding.setupContent.getRoot().setVisibility(View.GONE);
                 binding.boardContainer.setVisibility(View.VISIBLE);
                 inputsInitialized = false;
+
+                int playerCount = uiState.getPlayerCount();
+                if (binding.boardContainer.getChildCount() == 0 || currentBoardPlayerCount != playerCount) {
+                    binding.boardContainer.removeAllViews();
+                    LayoutInflater inflater = LayoutInflater.from(requireContext());
+                    currentBoardPlayerCount = playerCount;
+
+                    switch (playerCount) {
+                        case 1:
+                            LifeBoard1Binding.inflate(inflater, binding.boardContainer, true);
+                            break;
+                        case 2:
+                            LifeBoard2Binding.inflate(inflater, binding.boardContainer, true);
+                            break;
+                        case 3:
+                            LifeBoard3Binding.inflate(inflater, binding.boardContainer, true);
+                            break;
+                        case 4:
+                            LifeBoard4Binding.inflate(inflater, binding.boardContainer, true);
+                            break;
+                        case 5:
+                            LifeBoard5Binding.inflate(inflater, binding.boardContainer, true);
+                            break;
+                        case 6:
+                            LifeBoard6Binding.inflate(inflater, binding.boardContainer, true);
+                            break;
+                    }
+                }
+
+                // Bind player tiles
+                for (int i = 0; i < playerCount; i++) {
+                    int seatId;
+                    switch (i) {
+                        case 0: seatId = R.id.player_1; break;
+                        case 1: seatId = R.id.player_2; break;
+                        case 2: seatId = R.id.player_3; break;
+                        case 3: seatId = R.id.player_4; break;
+                        case 4: seatId = R.id.player_5; break;
+                        case 5: seatId = R.id.player_6; break;
+                        default: continue;
+                    }
+                    View cellView = binding.boardContainer.findViewById(seatId);
+                    if (cellView != null) {
+                        LifePlayerCellBinding cellBinding = LifePlayerCellBinding.bind(cellView);
+                        LifePlayerUiModel player = uiState.getPlayers().get(i);
+
+                        cellBinding.tvPlayerLabel.setText(getString(R.string.mtg_player_label, player.getSeatIndex() + 1));
+                        cellBinding.tvLifeCount.setText(String.valueOf(player.getLifeTotal()));
+
+                        int bgColor = requireContext().getColor(player.getBackgroundColorRes());
+                        int fgColor = requireContext().getColor(player.getForegroundColorRes());
+
+                        cellBinding.playerCellContainer.setBackgroundColor(bgColor);
+                        cellBinding.tvPlayerLabel.setTextColor(fgColor);
+                        cellBinding.tvLifeCount.setTextColor(fgColor);
+
+                        cellBinding.btnMinus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
+                        cellBinding.btnPlus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
+
+                        cellBinding.playerCellContainer.setRotation(player.getRotationDegrees());
+
+                        final int seatIndex = player.getSeatIndex();
+                        cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
+                        cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+
+                        cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
+                        cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+                    }
+                }
             }
         });
 

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -9,6 +9,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.core.view.MenuHost;
+import androidx.core.view.MenuProvider;
+import androidx.lifecycle.Lifecycle;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 
 import com.nicue.onetwo.R;
 import com.nicue.onetwo.databinding.LifeFragmentBinding;
@@ -21,7 +27,7 @@ import com.nicue.onetwo.databinding.LifeBoard5Binding;
 import com.nicue.onetwo.databinding.LifeBoard6Binding;
 import com.nicue.onetwo.databinding.LifePlayerCellBinding;
 
-public class MtgLifeFragment extends Fragment {
+public class MtgLifeFragment extends Fragment implements MenuProvider {
 
     private LifeFragmentBinding binding;
     private MtgLifeViewModel viewModel;
@@ -44,6 +50,8 @@ public class MtgLifeFragment extends Fragment {
         LifeSetupContentBinding setupBinding = LifeSetupContentBinding.bind(binding.setupContent.getRoot());
 
         viewModel.getUiState().observe(getViewLifecycleOwner(), uiState -> {
+            requireActivity().invalidateOptionsMenu();
+
             if (uiState.isShowingSetup()) {
                 binding.setupContent.getRoot().setVisibility(View.VISIBLE);
                 binding.boardContainer.setVisibility(View.GONE);
@@ -146,6 +154,27 @@ public class MtgLifeFragment extends Fragment {
             String lifeStr = setupBinding.lifeInput.getText().toString();
             viewModel.validateAndStartGame(playersStr, lifeStr);
         });
+
+        MenuHost menuHost = requireActivity();
+        menuHost.addMenuProvider(this, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+    }
+
+    @Override
+    public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+        menuInflater.inflate(R.menu.life_actions, menu);
+        MenuItem newGameItem = menu.findItem(R.id.action_new_game);
+        if (newGameItem != null && viewModel != null && viewModel.getUiState().getValue() != null) {
+            newGameItem.setVisible(!viewModel.getUiState().getValue().isShowingSetup());
+        }
+    }
+
+    @Override
+    public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+        if (menuItem.getItemId() == R.id.action_new_game) {
+            viewModel.resetToSetup();
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -136,7 +136,12 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         cellBinding.btnMinus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
                         cellBinding.btnPlus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
 
-                        cellBinding.playerCellContainer.setRotation(player.getRotationDegrees());
+                        float rotation = player.getRotationDegrees();
+                        cellBinding.playerCellContainer.setRotation(0f);
+                        cellBinding.tvPlayerLabel.setRotation(rotation);
+                        cellBinding.tvLifeCount.setRotation(rotation);
+                        cellBinding.btnMinus.setRotation(rotation);
+                        cellBinding.btnPlus.setRotation(rotation);
 
                         final int seatIndex = player.getSeatIndex();
                         cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -123,25 +123,19 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         LifePlayerCellBinding cellBinding = LifePlayerCellBinding.bind(cellView);
                         LifePlayerUiModel player = uiState.getPlayers().get(i);
 
-                        cellBinding.tvPlayerLabel.setText(getString(R.string.mtg_player_label, player.getSeatIndex() + 1));
                         cellBinding.tvLifeCount.setText(String.valueOf(player.getLifeTotal()));
 
                         int bgColor = requireContext().getColor(player.getBackgroundColorRes());
                         int fgColor = requireContext().getColor(player.getForegroundColorRes());
 
                         cellBinding.playerCellContainer.setBackgroundColor(bgColor);
-                        cellBinding.tvPlayerLabel.setTextColor(fgColor);
                         cellBinding.tvLifeCount.setTextColor(fgColor);
 
                         cellBinding.btnMinus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
                         cellBinding.btnPlus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
 
                         float rotation = player.getRotationDegrees();
-                        cellBinding.playerCellContainer.setRotation(0f);
-                        cellBinding.tvPlayerLabel.setRotation(rotation);
-                        cellBinding.tvLifeCount.setRotation(rotation);
-                        cellBinding.btnMinus.setRotation(rotation);
-                        cellBinding.btnPlus.setRotation(rotation);
+                        cellBinding.playerCellContainer.setRotation(rotation);
 
                         final int seatIndex = player.getSeatIndex();
                         cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -123,7 +123,26 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         LifePlayerCellBinding cellBinding = LifePlayerCellBinding.bind(cellView);
                         LifePlayerUiModel player = uiState.getPlayers().get(i);
 
+                        int maxSizeSp;
+                        switch (playerCount) {
+                            case 1: maxSizeSp = 96; break;
+                            case 2: maxSizeSp = 80; break;
+                            case 3: maxSizeSp = 72; break;
+                            case 4: maxSizeSp = 60; break;
+                            case 5: maxSizeSp = 54; break;
+                            case 6: maxSizeSp = 48; break;
+                            default: maxSizeSp = 60; break;
+                        }
+                        androidx.core.widget.TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+                            cellBinding.tvLifeCount,
+                            20,
+                            maxSizeSp,
+                            2,
+                            android.util.TypedValue.COMPLEX_UNIT_SP
+                        );
+
                         cellBinding.tvLifeCount.setText(String.valueOf(player.getLifeTotal()));
+                        cellBinding.tvLifeCount.setContentDescription(String.valueOf(player.getLifeTotal()));
 
                         int bgColor = requireContext().getColor(player.getBackgroundColorRes());
                         int fgColor = requireContext().getColor(player.getForegroundColorRes());

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -1,0 +1,94 @@
+package com.nicue.onetwo.ui.life;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.nicue.onetwo.R;
+import com.nicue.onetwo.databinding.LifeFragmentBinding;
+import com.nicue.onetwo.databinding.LifeSetupContentBinding;
+
+public class MtgLifeFragment extends Fragment {
+
+    private LifeFragmentBinding binding;
+    private MtgLifeViewModel viewModel;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = LifeFragmentBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        viewModel = new ViewModelProvider(this).get(MtgLifeViewModel.class);
+        
+        LifeSetupContentBinding setupBinding = LifeSetupContentBinding.bind(binding.setupContent.getRoot());
+
+        viewModel.getUiState().observe(getViewLifecycleOwner(), uiState -> {
+            if (uiState.isShowingSetup()) {
+                binding.setupContent.getRoot().setVisibility(View.VISIBLE);
+                binding.boardContainer.setVisibility(View.GONE);
+                
+                setupBinding.playersInput.setText(String.valueOf(uiState.getPlayerCount()));
+                setupBinding.lifeInput.setText(String.valueOf(uiState.getStartingLife()));
+                setupBinding.playersInputLayout.setError(null);
+                setupBinding.lifeInputLayout.setError(null);
+            } else {
+                binding.setupContent.getRoot().setVisibility(View.GONE);
+                binding.boardContainer.setVisibility(View.VISIBLE);
+            }
+        });
+
+        setupBinding.startGameButton.setOnClickListener(v -> {
+            String playersStr = setupBinding.playersInput.getText().toString();
+            String lifeStr = setupBinding.lifeInput.getText().toString();
+            
+            boolean valid = true;
+            try {
+                int players = Integer.parseInt(playersStr);
+                if (players < 1 || players > 6) {
+                    setupBinding.playersInputLayout.setError(getString(R.string.mtg_setup_players_error));
+                    valid = false;
+                } else {
+                    setupBinding.playersInputLayout.setError(null);
+                }
+            } catch (NumberFormatException e) {
+                setupBinding.playersInputLayout.setError(getString(R.string.mtg_setup_players_error));
+                valid = false;
+            }
+
+            try {
+                int life = Integer.parseInt(lifeStr);
+                if (life <= 0) {
+                    setupBinding.lifeInputLayout.setError(getString(R.string.mtg_setup_life_error));
+                    valid = false;
+                } else {
+                    setupBinding.lifeInputLayout.setError(null);
+                }
+            } catch (NumberFormatException e) {
+                setupBinding.lifeInputLayout.setError(getString(R.string.mtg_setup_life_error));
+                valid = false;
+            }
+
+            if (valid) {
+                viewModel.validateAndStartGame(playersStr, lifeStr);
+            }
+        });
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -2,30 +2,28 @@ package com.nicue.onetwo.ui.life;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProvider;
-import androidx.core.view.MenuHost;
-import androidx.core.view.MenuProvider;
-import androidx.lifecycle.Lifecycle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.MenuHost;
+import androidx.core.view.MenuProvider;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.ViewModelProvider;
 import com.nicue.onetwo.R;
-import com.nicue.onetwo.databinding.LifeFragmentBinding;
-import com.nicue.onetwo.databinding.LifeSetupContentBinding;
 import com.nicue.onetwo.databinding.LifeBoard1Binding;
 import com.nicue.onetwo.databinding.LifeBoard2Binding;
 import com.nicue.onetwo.databinding.LifeBoard3Binding;
 import com.nicue.onetwo.databinding.LifeBoard4Binding;
 import com.nicue.onetwo.databinding.LifeBoard5Binding;
 import com.nicue.onetwo.databinding.LifeBoard6Binding;
+import com.nicue.onetwo.databinding.LifeFragmentBinding;
 import com.nicue.onetwo.databinding.LifePlayerCellBinding;
+import com.nicue.onetwo.databinding.LifeSetupContentBinding;
 
 public class MtgLifeFragment extends Fragment implements MenuProvider {
 
@@ -34,9 +32,11 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     private boolean inputsInitialized = false;
     private int currentBoardPlayerCount = -1;
 
-    @Nullable
-    @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    @Nullable @Override
+    public View onCreateView(
+            @NonNull LayoutInflater inflater,
+            @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
         binding = LifeFragmentBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
@@ -46,133 +46,195 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         super.onViewCreated(view, savedInstanceState);
 
         viewModel = new ViewModelProvider(this).get(MtgLifeViewModel.class);
-        
-        LifeSetupContentBinding setupBinding = LifeSetupContentBinding.bind(binding.setupContent.getRoot());
 
-        viewModel.getUiState().observe(getViewLifecycleOwner(), uiState -> {
-            requireActivity().invalidateOptionsMenu();
+        LifeSetupContentBinding setupBinding =
+                LifeSetupContentBinding.bind(binding.setupContent.getRoot());
 
-            if (uiState.isShowingSetup()) {
-                binding.setupContent.getRoot().setVisibility(View.VISIBLE);
-                binding.boardContainer.setVisibility(View.GONE);
-                
-                if (!inputsInitialized) {
-                    setupBinding.playersInput.setText(String.valueOf(uiState.getPlayerCount()));
-                    setupBinding.lifeInput.setText(String.valueOf(uiState.getStartingLife()));
-                    inputsInitialized = true;
-                }
+        viewModel
+                .getUiState()
+                .observe(
+                        getViewLifecycleOwner(),
+                        uiState -> {
+                            requireActivity().invalidateOptionsMenu();
 
-                if (uiState.getPlayersErrorResId() != null) {
-                    setupBinding.playersInputLayout.setError(getString(uiState.getPlayersErrorResId()));
-                } else {
-                    setupBinding.playersInputLayout.setError(null);
-                }
+                            if (uiState.isShowingSetup()) {
+                                binding.setupContent.getRoot().setVisibility(View.VISIBLE);
+                                binding.boardContainer.setVisibility(View.GONE);
 
-                if (uiState.getLifeErrorResId() != null) {
-                    setupBinding.lifeInputLayout.setError(getString(uiState.getLifeErrorResId()));
-                } else {
-                    setupBinding.lifeInputLayout.setError(null);
-                }
-            } else {
-                binding.setupContent.getRoot().setVisibility(View.GONE);
-                binding.boardContainer.setVisibility(View.VISIBLE);
-                inputsInitialized = false;
+                                if (!inputsInitialized) {
+                                    setupBinding.playersInput.setText(
+                                            String.valueOf(uiState.getPlayerCount()));
+                                    setupBinding.lifeInput.setText(
+                                            String.valueOf(uiState.getStartingLife()));
+                                    inputsInitialized = true;
+                                }
 
-                int playerCount = uiState.getPlayerCount();
-                if (binding.boardContainer.getChildCount() == 0 || currentBoardPlayerCount != playerCount) {
-                    binding.boardContainer.removeAllViews();
-                    LayoutInflater inflater = LayoutInflater.from(requireContext());
-                    currentBoardPlayerCount = playerCount;
+                                if (uiState.getPlayersErrorResId() != null) {
+                                    setupBinding.playersInputLayout.setError(
+                                            getString(uiState.getPlayersErrorResId()));
+                                } else {
+                                    setupBinding.playersInputLayout.setError(null);
+                                }
 
-                    switch (playerCount) {
-                        case 1:
-                            LifeBoard1Binding.inflate(inflater, binding.boardContainer, true);
-                            break;
-                        case 2:
-                            LifeBoard2Binding.inflate(inflater, binding.boardContainer, true);
-                            break;
-                        case 3:
-                            LifeBoard3Binding.inflate(inflater, binding.boardContainer, true);
-                            break;
-                        case 4:
-                            LifeBoard4Binding.inflate(inflater, binding.boardContainer, true);
-                            break;
-                        case 5:
-                            LifeBoard5Binding.inflate(inflater, binding.boardContainer, true);
-                            break;
-                        case 6:
-                            LifeBoard6Binding.inflate(inflater, binding.boardContainer, true);
-                            break;
-                    }
-                }
+                                if (uiState.getLifeErrorResId() != null) {
+                                    setupBinding.lifeInputLayout.setError(
+                                            getString(uiState.getLifeErrorResId()));
+                                } else {
+                                    setupBinding.lifeInputLayout.setError(null);
+                                }
+                            } else {
+                                binding.setupContent.getRoot().setVisibility(View.GONE);
+                                binding.boardContainer.setVisibility(View.VISIBLE);
+                                inputsInitialized = false;
 
-                // Bind player tiles
-                for (int i = 0; i < playerCount; i++) {
-                    int seatId;
-                    switch (i) {
-                        case 0: seatId = R.id.player_1; break;
-                        case 1: seatId = R.id.player_2; break;
-                        case 2: seatId = R.id.player_3; break;
-                        case 3: seatId = R.id.player_4; break;
-                        case 4: seatId = R.id.player_5; break;
-                        case 5: seatId = R.id.player_6; break;
-                        default: continue;
-                    }
-                    View cellView = binding.boardContainer.findViewById(seatId);
-                    if (cellView != null) {
-                        LifePlayerCellBinding cellBinding = LifePlayerCellBinding.bind(cellView);
-                        LifePlayerUiModel player = uiState.getPlayers().get(i);
+                                int playerCount = uiState.getPlayerCount();
+                                if (binding.boardContainer.getChildCount() == 0
+                                        || currentBoardPlayerCount != playerCount) {
+                                    binding.boardContainer.removeAllViews();
+                                    LayoutInflater inflater = LayoutInflater.from(requireContext());
+                                    currentBoardPlayerCount = playerCount;
 
-                        int maxSizeSp;
-                        switch (playerCount) {
-                            case 1: maxSizeSp = 96; break;
-                            case 2: maxSizeSp = 80; break;
-                            case 3: maxSizeSp = 72; break;
-                            case 4: maxSizeSp = 60; break;
-                            case 5: maxSizeSp = 54; break;
-                            case 6: maxSizeSp = 48; break;
-                            default: maxSizeSp = 60; break;
-                        }
-                        androidx.core.widget.TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
-                            cellBinding.tvLifeCount,
-                            20,
-                            maxSizeSp,
-                            2,
-                            android.util.TypedValue.COMPLEX_UNIT_SP
-                        );
+                                    switch (playerCount) {
+                                        case 1:
+                                            LifeBoard1Binding.inflate(
+                                                    inflater, binding.boardContainer, true);
+                                            break;
+                                        case 2:
+                                            LifeBoard2Binding.inflate(
+                                                    inflater, binding.boardContainer, true);
+                                            break;
+                                        case 3:
+                                            LifeBoard3Binding.inflate(
+                                                    inflater, binding.boardContainer, true);
+                                            break;
+                                        case 4:
+                                            LifeBoard4Binding.inflate(
+                                                    inflater, binding.boardContainer, true);
+                                            break;
+                                        case 5:
+                                            LifeBoard5Binding.inflate(
+                                                    inflater, binding.boardContainer, true);
+                                            break;
+                                        case 6:
+                                            LifeBoard6Binding.inflate(
+                                                    inflater, binding.boardContainer, true);
+                                            break;
+                                    }
+                                }
 
-                        cellBinding.tvLifeCount.setText(String.valueOf(player.getLifeTotal()));
-                        cellBinding.tvLifeCount.setContentDescription(String.valueOf(player.getLifeTotal()));
+                                // Bind player tiles
+                                for (int i = 0; i < playerCount; i++) {
+                                    int seatId;
+                                    switch (i) {
+                                        case 0:
+                                            seatId = R.id.player_1;
+                                            break;
+                                        case 1:
+                                            seatId = R.id.player_2;
+                                            break;
+                                        case 2:
+                                            seatId = R.id.player_3;
+                                            break;
+                                        case 3:
+                                            seatId = R.id.player_4;
+                                            break;
+                                        case 4:
+                                            seatId = R.id.player_5;
+                                            break;
+                                        case 5:
+                                            seatId = R.id.player_6;
+                                            break;
+                                        default:
+                                            continue;
+                                    }
+                                    View cellView = binding.boardContainer.findViewById(seatId);
+                                    if (cellView != null) {
+                                        LifePlayerCellBinding cellBinding =
+                                                LifePlayerCellBinding.bind(cellView);
+                                        LifePlayerUiModel player = uiState.getPlayers().get(i);
 
-                        int bgColor = requireContext().getColor(player.getBackgroundColorRes());
-                        int fgColor = requireContext().getColor(player.getForegroundColorRes());
+                                        int maxSizeSp;
+                                        switch (playerCount) {
+                                            case 1:
+                                                maxSizeSp = 96;
+                                                break;
+                                            case 2:
+                                                maxSizeSp = 80;
+                                                break;
+                                            case 3:
+                                                maxSizeSp = 72;
+                                                break;
+                                            case 4:
+                                                maxSizeSp = 60;
+                                                break;
+                                            case 5:
+                                                maxSizeSp = 54;
+                                                break;
+                                            case 6:
+                                                maxSizeSp = 48;
+                                                break;
+                                            default:
+                                                maxSizeSp = 60;
+                                                break;
+                                        }
+                                        androidx.core.widget.TextViewCompat
+                                                .setAutoSizeTextTypeUniformWithConfiguration(
+                                                        cellBinding.tvLifeCount,
+                                                        20,
+                                                        maxSizeSp,
+                                                        2,
+                                                        android.util.TypedValue.COMPLEX_UNIT_SP);
 
-                        cellBinding.playerCellContainer.setBackgroundColor(bgColor);
-                        cellBinding.tvLifeCount.setTextColor(fgColor);
+                                        cellBinding.tvLifeCount.setText(
+                                                String.valueOf(player.getLifeTotal()));
+                                        cellBinding.tvLifeCount.setContentDescription(
+                                                String.valueOf(player.getLifeTotal()));
 
-                        cellBinding.btnMinus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
-                        cellBinding.btnPlus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
+                                        int bgColor =
+                                                requireContext()
+                                                        .getColor(player.getBackgroundColorRes());
+                                        int fgColor =
+                                                requireContext()
+                                                        .getColor(player.getForegroundColorRes());
 
-                        final int seatIndex = player.getSeatIndex();
-                        cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
-                        cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+                                        cellBinding.playerCellContainer.setBackgroundColor(bgColor);
+                                        cellBinding.tvLifeCount.setTextColor(fgColor);
 
-                        cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
-                        cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+                                        cellBinding.btnMinus.setIconTint(
+                                                android.content.res.ColorStateList.valueOf(
+                                                        fgColor));
+                                        cellBinding.btnPlus.setIconTint(
+                                                android.content.res.ColorStateList.valueOf(
+                                                        fgColor));
 
-                        float rotation = player.getRotationDegrees();
-                        cellBinding.playerCellContainer.setRotation(0f);
-                        cellBinding.innerPlayerLayout.setRotation(rotation);
-                    }
-                }
-            }
-        });
+                                        final int seatIndex = player.getSeatIndex();
+                                        cellBinding.btnMinus.setOnClickListener(
+                                                v -> viewModel.decrementLife(seatIndex));
+                                        cellBinding.btnPlus.setOnClickListener(
+                                                v -> viewModel.incrementLife(seatIndex));
 
-        setupBinding.startGameButton.setOnClickListener(v -> {
-            String playersStr = setupBinding.playersInput.getText().toString();
-            String lifeStr = setupBinding.lifeInput.getText().toString();
-            viewModel.validateAndStartGame(playersStr, lifeStr);
-        });
+                                        cellBinding.btnMinus.setContentDescription(
+                                                getString(
+                                                        R.string.mtg_btn_minus_desc,
+                                                        seatIndex + 1));
+                                        cellBinding.btnPlus.setContentDescription(
+                                                getString(
+                                                        R.string.mtg_btn_plus_desc, seatIndex + 1));
+
+                                        float rotation = player.getRotationDegrees();
+                                        cellBinding.playerCellContainer.setRotation(0f);
+                                        cellBinding.innerPlayerLayout.setRotation(rotation);
+                                    }
+                                }
+                            }
+                        });
+
+        setupBinding.startGameButton.setOnClickListener(
+                v -> {
+                    String playersStr = setupBinding.playersInput.getText().toString();
+                    String lifeStr = setupBinding.lifeInput.getText().toString();
+                    viewModel.validateAndStartGame(playersStr, lifeStr);
+                });
 
         MenuHost menuHost = requireActivity();
         menuHost.addMenuProvider(this, getViewLifecycleOwner(), Lifecycle.State.RESUMED);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -131,42 +131,19 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         cellBinding.playerCellContainer.setBackgroundColor(bgColor);
                         cellBinding.tvLifeCount.setTextColor(fgColor);
 
-                        float rotation = player.getRotationDegrees();
-                        cellBinding.playerCellContainer.setRotation(0f);
-                        cellBinding.tvLifeCount.setRotation(rotation);
-
-                        final int seatIndex = player.getSeatIndex();
-
-                        // btn_plus is physically at the top, btn_minus is physically at the bottom.
-                        boolean topIsPlus = (rotation == 0f || rotation == 270f);
-
-                        if (topIsPlus) {
-                            // Top button acts as PLUS
-                            cellBinding.btnPlus.setIconResource(R.drawable.ic_add_24);
-                            cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
-                            cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
-
-                            // Bottom button acts as MINUS
-                            cellBinding.btnMinus.setIconResource(R.drawable.ic_remove_24);
-                            cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
-                            cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
-                        } else {
-                            // Top button acts as MINUS
-                            cellBinding.btnPlus.setIconResource(R.drawable.ic_remove_24);
-                            cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
-                            cellBinding.btnPlus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
-
-                            // Bottom button acts as PLUS
-                            cellBinding.btnMinus.setIconResource(R.drawable.ic_add_24);
-                            cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
-                            cellBinding.btnMinus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
-                        }
-
                         cellBinding.btnMinus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
                         cellBinding.btnPlus.setIconTint(android.content.res.ColorStateList.valueOf(fgColor));
 
-                        cellBinding.btnMinus.setRotation(rotation);
-                        cellBinding.btnPlus.setRotation(rotation);
+                        final int seatIndex = player.getSeatIndex();
+                        cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
+                        cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+
+                        cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
+                        cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+
+                        float rotation = player.getRotationDegrees();
+                        cellBinding.playerCellContainer.setRotation(0f);
+                        cellBinding.innerPlayerLayout.setRotation(rotation);
                     }
                 }
             }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
@@ -1,0 +1,33 @@
+package com.nicue.onetwo.ui.life;
+
+import java.util.List;
+
+public class MtgLifeUiState {
+    private final boolean showingSetup;
+    private final int playerCount;
+    private final int startingLife;
+    private final List<LifePlayerUiModel> players;
+
+    public MtgLifeUiState(boolean showingSetup, int playerCount, int startingLife, List<LifePlayerUiModel> players) {
+        this.showingSetup = showingSetup;
+        this.playerCount = playerCount;
+        this.startingLife = startingLife;
+        this.players = players;
+    }
+
+    public boolean isShowingSetup() {
+        return showingSetup;
+    }
+
+    public int getPlayerCount() {
+        return playerCount;
+    }
+
+    public int getStartingLife() {
+        return startingLife;
+    }
+
+    public List<LifePlayerUiModel> getPlayers() {
+        return players;
+    }
+}

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
@@ -10,7 +10,13 @@ public class MtgLifeUiState {
     private final Integer playersErrorResId;
     private final Integer lifeErrorResId;
 
-    public MtgLifeUiState(boolean showingSetup, int playerCount, int startingLife, List<LifePlayerUiModel> players, Integer playersErrorResId, Integer lifeErrorResId) {
+    public MtgLifeUiState(
+            boolean showingSetup,
+            int playerCount,
+            int startingLife,
+            List<LifePlayerUiModel> players,
+            Integer playersErrorResId,
+            Integer lifeErrorResId) {
         this.showingSetup = showingSetup;
         this.playerCount = playerCount;
         this.startingLife = startingLife;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
@@ -7,12 +7,16 @@ public class MtgLifeUiState {
     private final int playerCount;
     private final int startingLife;
     private final List<LifePlayerUiModel> players;
+    private final Integer playersErrorResId;
+    private final Integer lifeErrorResId;
 
-    public MtgLifeUiState(boolean showingSetup, int playerCount, int startingLife, List<LifePlayerUiModel> players) {
+    public MtgLifeUiState(boolean showingSetup, int playerCount, int startingLife, List<LifePlayerUiModel> players, Integer playersErrorResId, Integer lifeErrorResId) {
         this.showingSetup = showingSetup;
         this.playerCount = playerCount;
         this.startingLife = startingLife;
         this.players = players;
+        this.playersErrorResId = playersErrorResId;
+        this.lifeErrorResId = lifeErrorResId;
     }
 
     public boolean isShowingSetup() {
@@ -29,5 +33,13 @@ public class MtgLifeUiState {
 
     public List<LifePlayerUiModel> getPlayers() {
         return players;
+    }
+
+    public Integer getPlayersErrorResId() {
+        return playersErrorResId;
+    }
+
+    public Integer getLifeErrorResId() {
+        return lifeErrorResId;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -112,6 +112,51 @@ public class MtgLifeViewModel extends ViewModel {
         updateUiState();
     }
 
+    private int getRotationForSeat(int seatIndex, int totalPlayers) {
+        switch (totalPlayers) {
+            case 1:
+                return 0;
+            case 2:
+                return (seatIndex == 0) ? 180 : 0;
+            case 3:
+                if (seatIndex == 0) return 180;
+                if (seatIndex == 1) return 270;
+                return 90;
+            case 4:
+                return (seatIndex < 2) ? 180 : 0;
+            case 5:
+                return (seatIndex < 2) ? 180 : 0;
+            case 6:
+                return (seatIndex < 3) ? 180 : 0;
+            default:
+                return 0;
+        }
+    }
+
+    private int getBackgroundColorResForSeat(int seatIndex) {
+        switch (seatIndex) {
+            case 0: return R.color.lifeCounterPlayer1;
+            case 1: return R.color.lifeCounterPlayer2;
+            case 2: return R.color.lifeCounterPlayer3;
+            case 3: return R.color.lifeCounterPlayer4;
+            case 4: return R.color.lifeCounterPlayer5;
+            case 5: return R.color.lifeCounterPlayer6;
+            default: return R.color.lifeCounterPlayer1;
+        }
+    }
+
+    private int getForegroundColorResForSeat(int seatIndex) {
+        switch (seatIndex) {
+            case 0: return R.color.lifeCounterOnPlayer1;
+            case 1: return R.color.lifeCounterOnPlayer2;
+            case 2: return R.color.lifeCounterOnPlayer3;
+            case 3: return R.color.lifeCounterOnPlayer4;
+            case 4: return R.color.lifeCounterOnPlayer5;
+            case 5: return R.color.lifeCounterOnPlayer6;
+            default: return R.color.lifeCounterOnPlayer1;
+        }
+    }
+
     private void updateUiState() {
         boolean showingSetup = savedStateHandle.get(KEY_SHOWING_SETUP);
         int playerCount = savedStateHandle.get(KEY_PLAYER_COUNT);
@@ -122,8 +167,12 @@ public class MtgLifeViewModel extends ViewModel {
 
         List<LifePlayerUiModel> playerModels = new ArrayList<>();
         if (!showingSetup && currentLives != null) {
-            for (int i = 0; i < currentLives.size(); i++) {
-                playerModels.add(new LifePlayerUiModel(i, currentLives.get(i), 0, 0, 0));
+            int size = currentLives.size();
+            for (int i = 0; i < size; i++) {
+                int rotation = getRotationForSeat(i, size);
+                int bg = getBackgroundColorResForSeat(i);
+                int fg = getForegroundColorResForSeat(i);
+                playerModels.add(new LifePlayerUiModel(i, currentLives.get(i), rotation, bg, fg));
             }
         }
 

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -120,14 +120,18 @@ public class MtgLifeViewModel extends ViewModel {
                 return (seatIndex == 0) ? 180 : 0;
             case 3:
                 if (seatIndex == 0) return 180;
-                if (seatIndex == 1) return 270;
-                return 90;
+                if (seatIndex == 1) return 90;
+                return 270;
             case 4:
-                return (seatIndex < 2) ? 180 : 0;
+                return (seatIndex % 2 == 0) ? 90 : 270;
             case 5:
-                return (seatIndex < 2) ? 180 : 0;
+                if (seatIndex == 4) return 0;
+                return (seatIndex % 2 == 0) ? 90 : 270;
             case 6:
-                return (seatIndex < 3) ? 180 : 0;
+                if (seatIndex == 1) return 180;
+                if (seatIndex == 4) return 0;
+                if (seatIndex == 0 || seatIndex == 3) return 90;
+                return 270;
             default:
                 return 0;
         }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -128,10 +128,7 @@ public class MtgLifeViewModel extends ViewModel {
                 if (seatIndex == 4) return 0;
                 return (seatIndex % 2 == 0) ? 90 : 270;
             case 6:
-                if (seatIndex == 1) return 180;
-                if (seatIndex == 4) return 0;
-                if (seatIndex == 0 || seatIndex == 3) return 90;
-                return 270;
+                return (seatIndex % 2 == 0) ? 90 : 270;
             default:
                 return 0;
         }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -1,0 +1,103 @@
+package com.nicue.onetwo.ui.life;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.SavedStateHandle;
+import androidx.lifecycle.ViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MtgLifeViewModel extends ViewModel {
+    private static final String KEY_SHOWING_SETUP = "showingSetup";
+    private static final String KEY_PLAYER_COUNT = "playerCount";
+    private static final String KEY_STARTING_LIFE = "startingLife";
+    private static final String KEY_CURRENT_LIVES = "currentLives";
+
+    private final SavedStateHandle savedStateHandle;
+    private final MutableLiveData<MtgLifeUiState> uiState = new MutableLiveData<>();
+
+    public MtgLifeViewModel(SavedStateHandle savedStateHandle) {
+        this.savedStateHandle = savedStateHandle;
+
+        if (!savedStateHandle.contains(KEY_SHOWING_SETUP)) {
+            savedStateHandle.set(KEY_SHOWING_SETUP, true);
+            savedStateHandle.set(KEY_PLAYER_COUNT, 4);
+            savedStateHandle.set(KEY_STARTING_LIFE, 40);
+            savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
+        }
+
+        updateUiState();
+    }
+
+    public LiveData<MtgLifeUiState> getUiState() {
+        return uiState;
+    }
+
+    public void validateAndStartGame(String playersStr, String lifeStr) {
+        try {
+            int players = Integer.parseInt(playersStr);
+            int life = Integer.parseInt(lifeStr);
+
+            if (players < 1 || players > 6) {
+                return;
+            }
+            if (life <= 0) {
+                return;
+            }
+
+            savedStateHandle.set(KEY_PLAYER_COUNT, players);
+            savedStateHandle.set(KEY_STARTING_LIFE, life);
+            
+            ArrayList<Integer> lives = new ArrayList<>();
+            for (int i = 0; i < players; i++) {
+                lives.add(life);
+            }
+            savedStateHandle.set(KEY_CURRENT_LIVES, lives);
+            savedStateHandle.set(KEY_SHOWING_SETUP, false);
+            
+            updateUiState();
+        } catch (NumberFormatException e) {
+            // Invalid input
+        }
+    }
+
+    public void incrementLife(int seatIndex) {
+        List<Integer> currentLives = new ArrayList<>(savedStateHandle.get(KEY_CURRENT_LIVES));
+        if (seatIndex >= 0 && seatIndex < currentLives.size()) {
+            currentLives.set(seatIndex, currentLives.get(seatIndex) + 1);
+            savedStateHandle.set(KEY_CURRENT_LIVES, currentLives);
+            updateUiState();
+        }
+    }
+
+    public void decrementLife(int seatIndex) {
+        List<Integer> currentLives = new ArrayList<>(savedStateHandle.get(KEY_CURRENT_LIVES));
+        if (seatIndex >= 0 && seatIndex < currentLives.size()) {
+            currentLives.set(seatIndex, currentLives.get(seatIndex) - 1);
+            savedStateHandle.set(KEY_CURRENT_LIVES, currentLives);
+            updateUiState();
+        }
+    }
+
+    public void resetToSetup() {
+        savedStateHandle.set(KEY_SHOWING_SETUP, true);
+        updateUiState();
+    }
+
+    private void updateUiState() {
+        boolean showingSetup = savedStateHandle.get(KEY_SHOWING_SETUP);
+        int playerCount = savedStateHandle.get(KEY_PLAYER_COUNT);
+        int startingLife = savedStateHandle.get(KEY_STARTING_LIFE);
+        List<Integer> currentLives = savedStateHandle.get(KEY_CURRENT_LIVES);
+
+        List<LifePlayerUiModel> playerModels = new ArrayList<>();
+        if (!showingSetup && currentLives != null) {
+            for (int i = 0; i < currentLives.size(); i++) {
+                playerModels.add(new LifePlayerUiModel(i, currentLives.get(i), 0, 0, 0));
+            }
+        }
+
+        uiState.setValue(new MtgLifeUiState(showingSetup, playerCount, startingLife, playerModels));
+    }
+}

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -4,9 +4,7 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.SavedStateHandle;
 import androidx.lifecycle.ViewModel;
-
 import com.nicue.onetwo.R;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -75,7 +73,7 @@ public class MtgLifeViewModel extends ViewModel {
         if (valid) {
             savedStateHandle.set(KEY_PLAYER_COUNT, players);
             savedStateHandle.set(KEY_STARTING_LIFE, life);
-            
+
             ArrayList<Integer> lives = new ArrayList<>();
             for (int i = 0; i < players; i++) {
                 lives.add(life);
@@ -136,25 +134,39 @@ public class MtgLifeViewModel extends ViewModel {
 
     private int getBackgroundColorResForSeat(int seatIndex) {
         switch (seatIndex) {
-            case 0: return R.color.lifeCounterPlayer1;
-            case 1: return R.color.lifeCounterPlayer2;
-            case 2: return R.color.lifeCounterPlayer3;
-            case 3: return R.color.lifeCounterPlayer4;
-            case 4: return R.color.lifeCounterPlayer5;
-            case 5: return R.color.lifeCounterPlayer6;
-            default: return R.color.lifeCounterPlayer1;
+            case 0:
+                return R.color.lifeCounterPlayer1;
+            case 1:
+                return R.color.lifeCounterPlayer2;
+            case 2:
+                return R.color.lifeCounterPlayer3;
+            case 3:
+                return R.color.lifeCounterPlayer4;
+            case 4:
+                return R.color.lifeCounterPlayer5;
+            case 5:
+                return R.color.lifeCounterPlayer6;
+            default:
+                return R.color.lifeCounterPlayer1;
         }
     }
 
     private int getForegroundColorResForSeat(int seatIndex) {
         switch (seatIndex) {
-            case 0: return R.color.lifeCounterOnPlayer1;
-            case 1: return R.color.lifeCounterOnPlayer2;
-            case 2: return R.color.lifeCounterOnPlayer3;
-            case 3: return R.color.lifeCounterOnPlayer4;
-            case 4: return R.color.lifeCounterOnPlayer5;
-            case 5: return R.color.lifeCounterOnPlayer6;
-            default: return R.color.lifeCounterOnPlayer1;
+            case 0:
+                return R.color.lifeCounterOnPlayer1;
+            case 1:
+                return R.color.lifeCounterOnPlayer2;
+            case 2:
+                return R.color.lifeCounterOnPlayer3;
+            case 3:
+                return R.color.lifeCounterOnPlayer4;
+            case 4:
+                return R.color.lifeCounterOnPlayer5;
+            case 5:
+                return R.color.lifeCounterOnPlayer6;
+            default:
+                return R.color.lifeCounterOnPlayer1;
         }
     }
 
@@ -177,6 +189,13 @@ public class MtgLifeViewModel extends ViewModel {
             }
         }
 
-        uiState.setValue(new MtgLifeUiState(showingSetup, playerCount, startingLife, playerModels, playersErrorResId, lifeErrorResId));
+        uiState.setValue(
+                new MtgLifeUiState(
+                        showingSetup,
+                        playerCount,
+                        startingLife,
+                        playerModels,
+                        playersErrorResId,
+                        lifeErrorResId));
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -5,6 +5,8 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.SavedStateHandle;
 import androidx.lifecycle.ViewModel;
 
+import com.nicue.onetwo.R;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +15,8 @@ public class MtgLifeViewModel extends ViewModel {
     private static final String KEY_PLAYER_COUNT = "playerCount";
     private static final String KEY_STARTING_LIFE = "startingLife";
     private static final String KEY_CURRENT_LIVES = "currentLives";
+    private static final String KEY_PLAYERS_ERROR_RES_ID = "playersErrorResId";
+    private static final String KEY_LIFE_ERROR_RES_ID = "lifeErrorResId";
 
     private final SavedStateHandle savedStateHandle;
     private final MutableLiveData<MtgLifeUiState> uiState = new MutableLiveData<>();
@@ -25,6 +29,8 @@ public class MtgLifeViewModel extends ViewModel {
             savedStateHandle.set(KEY_PLAYER_COUNT, 4);
             savedStateHandle.set(KEY_STARTING_LIFE, 40);
             savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
+            savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
+            savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
         }
 
         updateUiState();
@@ -35,17 +41,38 @@ public class MtgLifeViewModel extends ViewModel {
     }
 
     public void validateAndStartGame(String playersStr, String lifeStr) {
+        boolean valid = true;
+        Integer playersError = null;
+        Integer lifeError = null;
+
+        int players = 0;
         try {
-            int players = Integer.parseInt(playersStr);
-            int life = Integer.parseInt(lifeStr);
-
+            players = Integer.parseInt(playersStr);
             if (players < 1 || players > 6) {
-                return;
+                playersError = R.string.mtg_setup_players_error;
+                valid = false;
             }
-            if (life <= 0) {
-                return;
-            }
+        } catch (NumberFormatException e) {
+            playersError = R.string.mtg_setup_players_error;
+            valid = false;
+        }
 
+        int life = 0;
+        try {
+            life = Integer.parseInt(lifeStr);
+            if (life <= 0) {
+                lifeError = R.string.mtg_setup_life_error;
+                valid = false;
+            }
+        } catch (NumberFormatException e) {
+            lifeError = R.string.mtg_setup_life_error;
+            valid = false;
+        }
+
+        savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, playersError);
+        savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, lifeError);
+
+        if (valid) {
             savedStateHandle.set(KEY_PLAYER_COUNT, players);
             savedStateHandle.set(KEY_STARTING_LIFE, life);
             
@@ -55,11 +82,9 @@ public class MtgLifeViewModel extends ViewModel {
             }
             savedStateHandle.set(KEY_CURRENT_LIVES, lives);
             savedStateHandle.set(KEY_SHOWING_SETUP, false);
-            
-            updateUiState();
-        } catch (NumberFormatException e) {
-            // Invalid input
         }
+
+        updateUiState();
     }
 
     public void incrementLife(int seatIndex) {
@@ -82,6 +107,8 @@ public class MtgLifeViewModel extends ViewModel {
 
     public void resetToSetup() {
         savedStateHandle.set(KEY_SHOWING_SETUP, true);
+        savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
+        savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
         updateUiState();
     }
 
@@ -90,6 +117,8 @@ public class MtgLifeViewModel extends ViewModel {
         int playerCount = savedStateHandle.get(KEY_PLAYER_COUNT);
         int startingLife = savedStateHandle.get(KEY_STARTING_LIFE);
         List<Integer> currentLives = savedStateHandle.get(KEY_CURRENT_LIVES);
+        Integer playersErrorResId = savedStateHandle.get(KEY_PLAYERS_ERROR_RES_ID);
+        Integer lifeErrorResId = savedStateHandle.get(KEY_LIFE_ERROR_RES_ID);
 
         List<LifePlayerUiModel> playerModels = new ArrayList<>();
         if (!showingSetup && currentLives != null) {
@@ -98,6 +127,6 @@ public class MtgLifeViewModel extends ViewModel {
             }
         }
 
-        uiState.setValue(new MtgLifeUiState(showingSetup, playerCount, startingLife, playerModels));
+        uiState.setValue(new MtgLifeUiState(showingSetup, playerCount, startingLife, playerModels, playersErrorResId, lifeErrorResId));
     }
 }

--- a/app/src/main/res/drawable/cards_playing_outline.xml
+++ b/app/src/main/res/drawable/cards_playing_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,2H9c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2zM19,18H9V4h10v14zM4,6v16h14v-2H6V6H4zM16.5,13.5l-2.5,3l-1.5,-2l-2.5,3h9l-2.5,-4z"/>
+</vector>

--- a/app/src/main/res/layout/life_board_1.xml
+++ b/app/src/main/res/layout/life_board_1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/player_1"
+        layout="@layout/life_player_cell"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/life_board_2.xml
+++ b/app/src/main/res/layout/life_board_2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/player_1"
+        layout="@layout/life_player_cell"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <include
+        android:id="@+id/player_2"
+        layout="@layout/life_player_cell"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/life_board_3.xml
+++ b/app/src/main/res/layout/life_board_3.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/player_1"
+        layout="@layout/life_player_cell"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_2"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_3"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/life_board_4.xml
+++ b/app/src/main/res/layout/life_board_4.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_1"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_2"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_3"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_4"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/life_board_5.xml
+++ b/app/src/main/res/layout/life_board_5.xml
@@ -46,13 +46,13 @@
             android:layout_height="match_parent"
             android:layout_weight="1" />
 
-        <include
-            android:id="@+id/player_5"
-            layout="@layout/life_player_cell"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1" />
-
     </LinearLayout>
+
+    <include
+        android:id="@+id/player_5"
+        layout="@layout/life_player_cell"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/life_board_5.xml
+++ b/app/src/main/res/layout/life_board_5.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_1"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_2"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_3"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_4"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_5"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/life_board_6.xml
+++ b/app/src/main/res/layout/life_board_6.xml
@@ -24,8 +24,23 @@
             android:layout_height="match_parent"
             android:layout_weight="1" />
 
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
         <include
             android:id="@+id/player_3"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_4"
             layout="@layout/life_player_cell"
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -38,13 +53,6 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:orientation="horizontal">
-
-        <include
-            android:id="@+id/player_4"
-            layout="@layout/life_player_cell"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1" />
 
         <include
             android:id="@+id/player_5"

--- a/app/src/main/res/layout/life_board_6.xml
+++ b/app/src/main/res/layout/life_board_6.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_1"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_2"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_3"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/player_4"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_5"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/player_6"
+            layout="@layout/life_player_cell"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/life_fragment.xml
+++ b/app/src/main/res/layout/life_fragment.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.life.MtgLifeFragment">
+
+    <FrameLayout
+        android:id="@+id/board_container"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include
+        android:id="@+id/setup_content"
+        layout="@layout/life_setup_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -6,36 +6,23 @@
     android:layout_height="match_parent"
     android:padding="@dimen/space_sm">
 
-    <TextView
-        android:id="@+id/tv_player_label"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:alpha="0.7"
-        android:includeFontPadding="false"
-        android:text="Player 1"
-        android:textAppearance="?attr/textAppearanceTitleMedium"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_minus"
+        android:id="@+id/btn_plus"
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="56dp"
         android:layout_height="56dp"
-        android:contentDescription="Decrease life"
+        android:contentDescription="Increase life"
         android:insetLeft="0dp"
         android:insetTop="0dp"
         android:insetRight="0dp"
         android:insetBottom="0dp"
-        app:icon="@drawable/ic_remove_24"
+        app:icon="@drawable/ic_add_24"
         app:iconGravity="textStart"
         app:iconPadding="0dp"
         app:iconSize="30dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_player_label" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tv_life_count"
@@ -51,22 +38,22 @@
         app:autoSizeMaxTextSize="108sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@id/btn_plus"
+        app:layout_constraintBottom_toTopOf="@id/btn_minus"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_minus" />
+        app:layout_constraintTop_toBottomOf="@id/btn_plus" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_plus"
+        android:id="@+id/btn_minus"
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="56dp"
         android:layout_height="56dp"
-        android:contentDescription="Increase life"
+        android:contentDescription="Decrease life"
         android:insetLeft="0dp"
         android:insetTop="0dp"
         android:insetRight="0dp"
         android:insetBottom="0dp"
-        app:icon="@drawable/ic_add_24"
+        app:icon="@drawable/ic_remove_24"
         app:iconGravity="textStart"
         app:iconPadding="0dp"
         app:iconSize="30dp"

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/player_cell_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tv_player_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:alpha="0.7"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:text="Player 1" />
+
+    <!-- Big auto-sizing life total -->
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tv_life_count"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:text="40"
+        android:textStyle="bold"
+        app:autoSizeMinTextSize="24sp"
+        app:autoSizeMaxTextSize="120sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_plus"
+        app:layout_constraintStart_toEndOf="@id/btn_minus"
+        app:layout_constraintTop_toBottomOf="@id/tv_player_label" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_minus"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:contentDescription="Decrease life"
+        android:insetLeft="0dp"
+        android:insetTop="0dp"
+        android:insetRight="0dp"
+        android:insetBottom="0dp"
+        app:icon="@drawable/ic_remove_24"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="36dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_plus"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:contentDescription="Increase life"
+        android:insetLeft="0dp"
+        android:insetTop="0dp"
+        android:insetRight="0dp"
+        android:insetBottom="0dp"
+        app:icon="@drawable/ic_add_24"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="36dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -4,43 +4,26 @@
     android:id="@+id/player_cell_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="8dp">
+    android:padding="@dimen/space_sm">
 
     <TextView
         android:id="@+id/tv_player_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:alpha="0.7"
+        android:includeFontPadding="false"
+        android:text="Player 1"
         android:textAppearance="?attr/textAppearanceTitleMedium"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:text="Player 1" />
-
-    <!-- Big auto-sizing life total -->
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/tv_life_count"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:text="40"
-        android:textStyle="bold"
-        app:autoSizeMinTextSize="24sp"
-        app:autoSizeMaxTextSize="120sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/btn_plus"
-        app:layout_constraintStart_toEndOf="@id/btn_minus"
-        app:layout_constraintTop_toBottomOf="@id/tv_player_label" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_minus"
         style="@style/Widget.MaterialComponents.Button.TextButton"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
         android:contentDescription="Decrease life"
         android:insetLeft="0dp"
         android:insetTop="0dp"
@@ -49,16 +32,35 @@
         app:icon="@drawable/ic_remove_24"
         app:iconGravity="textStart"
         app:iconPadding="0dp"
-        app:iconSize="36dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:iconSize="30dp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/tv_player_label" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tv_life_count"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:includeFontPadding="false"
+        android:maxLines="1"
+        android:text="40"
+        android:textSize="96sp"
+        android:textStyle="bold"
+        app:autoSizeMinTextSize="20sp"
+        app:autoSizeMaxTextSize="108sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@id/btn_plus"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_minus" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_plus"
         style="@style/Widget.MaterialComponents.Button.TextButton"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
         android:contentDescription="Increase life"
         android:insetLeft="0dp"
         android:insetTop="0dp"
@@ -67,9 +69,9 @@
         app:icon="@drawable/ic_add_24"
         app:iconGravity="textStart"
         app:iconPadding="0dp"
-        app:iconSize="36dp"
+        app:iconSize="30dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -50,6 +50,7 @@
             app:autoSizeTextType="uniform"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
+            app:layout_constraintHeight_percent="0.6"
             app:layout_constraintStart_toEndOf="@id/btn_minus"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -3,62 +3,74 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/player_cell_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="@dimen/space_sm">
+    android:layout_height="match_parent">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_plus"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
-        android:contentDescription="Increase life"
-        android:insetLeft="0dp"
-        android:insetTop="0dp"
-        android:insetRight="0dp"
-        android:insetBottom="0dp"
-        app:icon="@drawable/ic_add_24"
-        app:iconGravity="textStart"
-        app:iconPadding="0dp"
-        app:iconSize="30dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/tv_life_count"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/inner_player_layout"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:gravity="center"
-        android:includeFontPadding="false"
-        android:maxLines="1"
-        android:text="40"
-        android:textSize="96sp"
-        android:textStyle="bold"
-        app:autoSizeMinTextSize="20sp"
-        app:autoSizeMaxTextSize="108sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@id/btn_minus"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_plus" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_minus"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
-        android:contentDescription="Decrease life"
-        android:insetLeft="0dp"
-        android:insetTop="0dp"
-        android:insetRight="0dp"
-        android:insetBottom="0dp"
-        app:icon="@drawable/ic_remove_24"
-        app:iconGravity="textStart"
-        app:iconPadding="0dp"
-        app:iconSize="30dp"
+        app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:padding="@dimen/space_sm">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_minus"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:contentDescription="Decrease life"
+            android:insetLeft="0dp"
+            android:insetTop="0dp"
+            android:insetRight="0dp"
+            android:insetBottom="0dp"
+            app:icon="@drawable/ic_remove_24"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp"
+            app:iconSize="30dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_life_count"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:text="40"
+            android:textSize="96sp"
+            android:textStyle="bold"
+            app:autoSizeMinTextSize="20sp"
+            app:autoSizeMaxTextSize="108sp"
+            app:autoSizeStepGranularity="2sp"
+            app:autoSizeTextType="uniform"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_plus"
+            app:layout_constraintStart_toEndOf="@id/btn_minus"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_plus"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:contentDescription="Increase life"
+            android:insetLeft="0dp"
+            android:insetTop="0dp"
+            android:insetRight="0dp"
+            android:insetBottom="0dp"
+            app:icon="@drawable/ic_add_24"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp"
+            app:iconSize="30dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/life_setup_content.xml
+++ b/app/src/main/res/layout/life_setup_content.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="32dp"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/mtg_setup_title"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:textAlignment="center"
+            android:layout_marginBottom="24dp" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/players_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/mtg_setup_players"
+            app:errorEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/players_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/life_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:hint="@string/mtg_setup_life"
+            app:errorEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/life_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/start_game_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/mtg_setup_start" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -23,6 +23,11 @@
             android:icon="@drawable/timer_sand"
             android:title="@string/menu_timer" />
 
+        <item
+            android:id="@+id/nav_mtg_life"
+            android:icon="@drawable/cards_playing_outline"
+            android:title="@string/menu_mtg_life" />
+
     </group>
 
     <group

--- a/app/src/main/res/menu/life_actions.xml
+++ b/app/src/main/res/menu/life_actions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_new_game"
+        android:title="@string/mtg_setup_title"
+        app:showAsAction="always|withText" />
+</menu>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -28,4 +28,8 @@
         android:id="@+id/nav_settings"
         android:name="com.nicue.onetwo.ui.settings.SettingsFragment"
         android:label="@string/menu_settings" />
+    <fragment
+        android:id="@+id/nav_mtg_life"
+        android:name="com.nicue.onetwo.ui.life.MtgLifeFragment"
+        android:label="@string/menu_mtg_life" />
 </navigation>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -59,4 +59,11 @@
     <string name="colon">:</string>
     <string name="content_desc_add_counter">Agregar contador</string>
     <string name="content_desc_roll_dice">Lanzar dados</string>
+    <string name="menu_mtg_life">Contador de Vidas</string>
+    <string name="mtg_setup_title">Nueva Partida</string>
+    <string name="mtg_setup_players">Jugadores</string>
+    <string name="mtg_setup_life">Vidas</string>
+    <string name="mtg_setup_start">Empezar</string>
+    <string name="mtg_setup_players_error">Debe ser de 1 a 6</string>
+    <string name="mtg_setup_life_error">Debe ser mayor que 0</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -66,4 +66,7 @@
     <string name="mtg_setup_start">Empezar</string>
     <string name="mtg_setup_players_error">Debe ser de 1 a 6</string>
     <string name="mtg_setup_life_error">Debe ser mayor que 0</string>
+    <string name="mtg_player_label">Jugador %1$d</string>
+    <string name="mtg_btn_minus_desc">Disminuir vida para el jugador %1$d</string>
+    <string name="mtg_btn_plus_desc">Aumentar vida para el jugador %1$d</string>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -45,4 +45,18 @@
     <color name="diceColor2">#5DD8F4</color>
     <color name="diceColor3">#F3BB21</color>
     <color name="diceColor4">#B92130</color>
+
+    <!-- MTG Life Counter Colors -->
+    <color name="lifeCounterPlayer1">#184E75</color>
+    <color name="lifeCounterOnPlayer1">#D0E4FF</color>
+    <color name="lifeCounterPlayer2">#564500</color>
+    <color name="lifeCounterOnPlayer2">#FFE08A</color>
+    <color name="lifeCounterPlayer3">#930019</color>
+    <color name="lifeCounterOnPlayer3">#FFDAD8</color>
+    <color name="lifeCounterPlayer4">#00375E</color>
+    <color name="lifeCounterOnPlayer4">#E4F0FF</color>
+    <color name="lifeCounterPlayer5">#3F3200</color>
+    <color name="lifeCounterOnPlayer5">#FFF0C4</color>
+    <color name="lifeCounterPlayer6">#5A000D</color>
+    <color name="lifeCounterOnPlayer6">#FFEAEA</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -50,4 +50,18 @@
     <color name="diceColor7">#F3BB21</color>
     <color name="diceColor8">#BD2430</color>
     <color name="diceColor9">#F65B59</color>
+
+    <!-- MTG Life Counter Colors -->
+    <color name="lifeCounterPlayer1">#D0E4FF</color>
+    <color name="lifeCounterOnPlayer1">#001D35</color>
+    <color name="lifeCounterPlayer2">#FFE08A</color>
+    <color name="lifeCounterOnPlayer2">#231B00</color>
+    <color name="lifeCounterPlayer3">#FFDAD8</color>
+    <color name="lifeCounterOnPlayer3">#410006</color>
+    <color name="lifeCounterPlayer4">#E4F0FF</color>
+    <color name="lifeCounterOnPlayer4">#002D54</color>
+    <color name="lifeCounterPlayer5">#FFF0C4</color>
+    <color name="lifeCounterOnPlayer5">#403000</color>
+    <color name="lifeCounterPlayer6">#FFEAEA</color>
+    <color name="lifeCounterOnPlayer6">#6E0010</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,5 +73,8 @@
     <string name="mtg_setup_start">Start Game</string>
     <string name="mtg_setup_players_error">Must be 1 to 6</string>
     <string name="mtg_setup_life_error">Must be greater than 0</string>
+    <string name="mtg_player_label">Player %1$d</string>
+    <string name="mtg_btn_minus_desc">Decrease life for player %1$d</string>
+    <string name="mtg_btn_plus_desc">Increase life for player %1$d</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,4 +66,12 @@
     <string name="content_desc_add_counter">Add Counter</string>
     <string name="content_desc_roll_dice">Roll Dice</string>
 
+    <string name="menu_mtg_life">Life Counter</string>
+    <string name="mtg_setup_title">New Game</string>
+    <string name="mtg_setup_players">Players</string>
+    <string name="mtg_setup_life">Life</string>
+    <string name="mtg_setup_start">Start Game</string>
+    <string name="mtg_setup_players_error">Must be 1 to 6</string>
+    <string name="mtg_setup_life_error">Must be greater than 0</string>
+
 </resources>

--- a/app/src/test/java/com/nicue/onetwo/navigation/NavigationSmokeTest.java
+++ b/app/src/test/java/com/nicue/onetwo/navigation/NavigationSmokeTest.java
@@ -34,6 +34,9 @@ public class NavigationSmokeTest {
 
                 navController.navigate(R.id.nav_timer);
                 assertEquals(R.id.nav_timer, navController.getCurrentDestination().getId());
+
+                navController.navigate(R.id.nav_mtg_life);
+                assertEquals(R.id.nav_mtg_life, navController.getCurrentDestination().getId());
             });
         }
     }

--- a/app/src/test/java/com/nicue/onetwo/navigation/NavigationSmokeTest.java
+++ b/app/src/test/java/com/nicue/onetwo/navigation/NavigationSmokeTest.java
@@ -7,10 +7,8 @@ import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.test.core.app.ActivityScenario;
-
 import com.nicue.onetwo.MainActivity;
 import com.nicue.onetwo.R;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -21,23 +19,29 @@ import org.robolectric.annotation.Config;
 public class NavigationSmokeTest {
     @Test
     public void topLevelDestinations_areAvailableInNavGraph() {
-        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
-            scenario.onActivity(activity -> {
-                Fragment fragment = activity.getSupportFragmentManager()
-                        .findFragmentById(R.id.nav_host_fragment);
-                assertNotNull(fragment);
-                NavController navController = ((NavHostFragment) fragment).getNavController();
-                assertEquals(R.id.nav_counter, navController.getCurrentDestination().getId());
+        try (ActivityScenario<MainActivity> scenario =
+                ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(
+                    activity -> {
+                        Fragment fragment =
+                                activity.getSupportFragmentManager()
+                                        .findFragmentById(R.id.nav_host_fragment);
+                        assertNotNull(fragment);
+                        NavController navController =
+                                ((NavHostFragment) fragment).getNavController();
+                        assertEquals(
+                                R.id.nav_counter, navController.getCurrentDestination().getId());
 
-                navController.navigate(R.id.nav_dice);
-                assertEquals(R.id.nav_dice, navController.getCurrentDestination().getId());
+                        navController.navigate(R.id.nav_dice);
+                        assertEquals(R.id.nav_dice, navController.getCurrentDestination().getId());
 
-                navController.navigate(R.id.nav_timer);
-                assertEquals(R.id.nav_timer, navController.getCurrentDestination().getId());
+                        navController.navigate(R.id.nav_timer);
+                        assertEquals(R.id.nav_timer, navController.getCurrentDestination().getId());
 
-                navController.navigate(R.id.nav_mtg_life);
-                assertEquals(R.id.nav_mtg_life, navController.getCurrentDestination().getId());
-            });
+                        navController.navigate(R.id.nav_mtg_life);
+                        assertEquals(
+                                R.id.nav_mtg_life, navController.getCurrentDestination().getId());
+                    });
         }
     }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -1,0 +1,120 @@
+package com.nicue.onetwo.ui.life;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.fragment.app.testing.FragmentScenario;
+
+import com.nicue.onetwo.R;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class MtgLifeFragmentTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    @Test
+    public void testSetupStateVisibleOnFirstLaunchAndPrefilled() {
+        FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            assertNotNull(view);
+
+            View setupContent = view.findViewById(R.id.setup_content);
+            assertNotNull(setupContent);
+            assertEquals(View.VISIBLE, setupContent.getVisibility());
+
+            View boardContainer = view.findViewById(R.id.board_container);
+            assertNotNull(boardContainer);
+            assertEquals(View.GONE, boardContainer.getVisibility());
+
+            EditText playersInput = view.findViewById(R.id.players_input);
+            EditText lifeInput = view.findViewById(R.id.life_input);
+
+            assertNotNull(playersInput);
+            assertNotNull(lifeInput);
+
+            assertEquals("4", playersInput.getText().toString());
+            assertEquals("40", lifeInput.getText().toString());
+        });
+    }
+
+    @Test
+    public void testStartGameSwapsToBoardAndTappingPlusMinusUpdatesTotals() {
+        FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+
+        // 1. Press Start Game with defaults (4 players, 40 life)
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            Button startButton = view.findViewById(R.id.start_game_button);
+            assertNotNull(startButton);
+            startButton.performClick();
+        });
+
+        // 2. Verify we transitioned to playing board state (4 players board)
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            View setupContent = view.findViewById(R.id.setup_content);
+            assertEquals(View.GONE, setupContent.getVisibility());
+
+            View boardContainer = view.findViewById(R.id.board_container);
+            assertEquals(View.VISIBLE, boardContainer.getVisibility());
+
+            // 4-player board is inflated, check that R.id.player_1, player_2, player_3, player_4 are present
+            View player1 = view.findViewById(R.id.player_1);
+            View player2 = view.findViewById(R.id.player_2);
+            View player3 = view.findViewById(R.id.player_3);
+            View player4 = view.findViewById(R.id.player_4);
+
+            assertNotNull(player1);
+            assertNotNull(player2);
+            assertNotNull(player3);
+            assertNotNull(player4);
+
+            // Verify starting life totals are 40
+            TextView life1 = player1.findViewById(R.id.tv_life_count);
+            TextView life2 = player2.findViewById(R.id.tv_life_count);
+            assertEquals("40", life1.getText().toString());
+            assertEquals("40", life2.getText().toString());
+
+            // Tap R.id.btn_plus for player 1
+            View btnPlus1 = player1.findViewById(R.id.btn_plus);
+            assertNotNull(btnPlus1);
+            btnPlus1.performClick();
+
+            // Tap R.id.btn_minus for player 2
+            View btnMinus2 = player2.findViewById(R.id.btn_minus);
+            assertNotNull(btnMinus2);
+            btnMinus2.performClick();
+        });
+
+        // 3. Verify life totals are updated accordingly
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            View player1 = view.findViewById(R.id.player_1);
+            View player2 = view.findViewById(R.id.player_2);
+
+            TextView life1 = player1.findViewById(R.id.tv_life_count);
+            TextView life2 = player2.findViewById(R.id.tv_life_count);
+
+            assertEquals("41", life1.getText().toString());
+            assertEquals("39", life2.getText().toString());
+        });
+    }
+}

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -93,12 +93,12 @@ public class MtgLifeFragmentTest {
             assertEquals("40", life1.getText().toString());
             assertEquals("40", life2.getText().toString());
 
-            // Tap PLUS button for player 1 (which maps to R.id.btn_minus for 90-degree rotated seat)
-            View btnPlus1 = player1.findViewById(R.id.btn_minus);
+            // Tap PLUS button for player 1
+            View btnPlus1 = player1.findViewById(R.id.btn_plus);
             assertNotNull(btnPlus1);
             btnPlus1.performClick();
 
-            // Tap MINUS button for player 2 (which maps to R.id.btn_minus for 270-degree rotated seat)
+            // Tap MINUS button for player 2
             View btnMinus2 = player2.findViewById(R.id.btn_minus);
             assertNotNull(btnMinus2);
             btnMinus2.performClick();

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -7,12 +7,9 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.fragment.app.testing.FragmentScenario;
-
 import com.nicue.onetwo.R;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,35 +20,35 @@ import org.robolectric.annotation.Config;
 @Config(sdk = 34)
 public class MtgLifeFragmentTest {
 
-    @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     @Test
     public void testSetupStateVisibleOnFirstLaunchAndPrefilled() {
         FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
 
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            assertNotNull(view);
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    assertNotNull(view);
 
-            View setupContent = view.findViewById(R.id.setup_content);
-            assertNotNull(setupContent);
-            assertEquals(View.VISIBLE, setupContent.getVisibility());
+                    View setupContent = view.findViewById(R.id.setup_content);
+                    assertNotNull(setupContent);
+                    assertEquals(View.VISIBLE, setupContent.getVisibility());
 
-            View boardContainer = view.findViewById(R.id.board_container);
-            assertNotNull(boardContainer);
-            assertEquals(View.GONE, boardContainer.getVisibility());
+                    View boardContainer = view.findViewById(R.id.board_container);
+                    assertNotNull(boardContainer);
+                    assertEquals(View.GONE, boardContainer.getVisibility());
 
-            EditText playersInput = view.findViewById(R.id.players_input);
-            EditText lifeInput = view.findViewById(R.id.life_input);
+                    EditText playersInput = view.findViewById(R.id.players_input);
+                    EditText lifeInput = view.findViewById(R.id.life_input);
 
-            assertNotNull(playersInput);
-            assertNotNull(lifeInput);
+                    assertNotNull(playersInput);
+                    assertNotNull(lifeInput);
 
-            assertEquals("4", playersInput.getText().toString());
-            assertEquals("40", lifeInput.getText().toString());
-        });
+                    assertEquals("4", playersInput.getText().toString());
+                    assertEquals("40", lifeInput.getText().toString());
+                });
     }
 
     @Test
@@ -60,62 +57,66 @@ public class MtgLifeFragmentTest {
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
 
         // 1. Press Start Game with defaults (4 players, 40 life)
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            Button startButton = view.findViewById(R.id.start_game_button);
-            assertNotNull(startButton);
-            startButton.performClick();
-        });
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    Button startButton = view.findViewById(R.id.start_game_button);
+                    assertNotNull(startButton);
+                    startButton.performClick();
+                });
 
         // 2. Verify we transitioned to playing board state (4 players board)
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            View setupContent = view.findViewById(R.id.setup_content);
-            assertEquals(View.GONE, setupContent.getVisibility());
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    View setupContent = view.findViewById(R.id.setup_content);
+                    assertEquals(View.GONE, setupContent.getVisibility());
 
-            View boardContainer = view.findViewById(R.id.board_container);
-            assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                    View boardContainer = view.findViewById(R.id.board_container);
+                    assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-            // 4-player board is inflated, check that R.id.player_1, player_2, player_3, player_4 are present
-            View player1 = view.findViewById(R.id.player_1);
-            View player2 = view.findViewById(R.id.player_2);
-            View player3 = view.findViewById(R.id.player_3);
-            View player4 = view.findViewById(R.id.player_4);
+                    // 4-player board is inflated, check that R.id.player_1, player_2, player_3,
+                    // player_4 are present
+                    View player1 = view.findViewById(R.id.player_1);
+                    View player2 = view.findViewById(R.id.player_2);
+                    View player3 = view.findViewById(R.id.player_3);
+                    View player4 = view.findViewById(R.id.player_4);
 
-            assertNotNull(player1);
-            assertNotNull(player2);
-            assertNotNull(player3);
-            assertNotNull(player4);
+                    assertNotNull(player1);
+                    assertNotNull(player2);
+                    assertNotNull(player3);
+                    assertNotNull(player4);
 
-            // Verify starting life totals are 40
-            TextView life1 = player1.findViewById(R.id.tv_life_count);
-            TextView life2 = player2.findViewById(R.id.tv_life_count);
-            assertEquals("40", life1.getText().toString());
-            assertEquals("40", life2.getText().toString());
+                    // Verify starting life totals are 40
+                    TextView life1 = player1.findViewById(R.id.tv_life_count);
+                    TextView life2 = player2.findViewById(R.id.tv_life_count);
+                    assertEquals("40", life1.getText().toString());
+                    assertEquals("40", life2.getText().toString());
 
-            // Tap PLUS button for player 1
-            View btnPlus1 = player1.findViewById(R.id.btn_plus);
-            assertNotNull(btnPlus1);
-            btnPlus1.performClick();
+                    // Tap PLUS button for player 1
+                    View btnPlus1 = player1.findViewById(R.id.btn_plus);
+                    assertNotNull(btnPlus1);
+                    btnPlus1.performClick();
 
-            // Tap MINUS button for player 2
-            View btnMinus2 = player2.findViewById(R.id.btn_minus);
-            assertNotNull(btnMinus2);
-            btnMinus2.performClick();
-        });
+                    // Tap MINUS button for player 2
+                    View btnMinus2 = player2.findViewById(R.id.btn_minus);
+                    assertNotNull(btnMinus2);
+                    btnMinus2.performClick();
+                });
 
         // 3. Verify life totals are updated accordingly
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            View player1 = view.findViewById(R.id.player_1);
-            View player2 = view.findViewById(R.id.player_2);
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    View player1 = view.findViewById(R.id.player_1);
+                    View player2 = view.findViewById(R.id.player_2);
 
-            TextView life1 = player1.findViewById(R.id.tv_life_count);
-            TextView life2 = player2.findViewById(R.id.tv_life_count);
+                    TextView life1 = player1.findViewById(R.id.tv_life_count);
+                    TextView life2 = player2.findViewById(R.id.tv_life_count);
 
-            assertEquals("41", life1.getText().toString());
-            assertEquals("39", life2.getText().toString());
-        });
+                    assertEquals("41", life1.getText().toString());
+                    assertEquals("39", life2.getText().toString());
+                });
     }
 
     @Test
@@ -124,54 +125,60 @@ public class MtgLifeFragmentTest {
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
 
         // 1. Enter non-default setup, e.g., 3 players, 30 life, and start game
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            EditText playersInput = view.findViewById(R.id.players_input);
-            EditText lifeInput = view.findViewById(R.id.life_input);
-            playersInput.setText("3");
-            lifeInput.setText("30");
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    EditText playersInput = view.findViewById(R.id.players_input);
+                    EditText lifeInput = view.findViewById(R.id.life_input);
+                    playersInput.setText("3");
+                    lifeInput.setText("30");
 
-            Button startButton = view.findViewById(R.id.start_game_button);
-            startButton.performClick();
-        });
+                    Button startButton = view.findViewById(R.id.start_game_button);
+                    startButton.performClick();
+                });
 
         // 2. Verify we are playing 3 players game
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            View setupContent = view.findViewById(R.id.setup_content);
-            assertEquals(View.GONE, setupContent.getVisibility());
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    View setupContent = view.findViewById(R.id.setup_content);
+                    assertEquals(View.GONE, setupContent.getVisibility());
 
-            View boardContainer = view.findViewById(R.id.board_container);
-            assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                    View boardContainer = view.findViewById(R.id.board_container);
+                    assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-            View player1 = view.findViewById(R.id.player_1);
-            View player3 = view.findViewById(R.id.player_3);
-            assertNotNull(player1);
-            assertNotNull(player3);
+                    View player1 = view.findViewById(R.id.player_1);
+                    View player3 = view.findViewById(R.id.player_3);
+                    assertNotNull(player1);
+                    assertNotNull(player3);
 
-            TextView life1 = player1.findViewById(R.id.tv_life_count);
-            assertEquals("30", life1.getText().toString());
-        });
+                    TextView life1 = player1.findViewById(R.id.tv_life_count);
+                    assertEquals("30", life1.getText().toString());
+                });
 
         // 3. Trigger app-bar "New Game" menu action (action_new_game)
-        scenario.onFragment(fragment -> {
-            org.robolectric.fakes.RoboMenuItem resetMenuItem = new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
-            fragment.onMenuItemSelected(resetMenuItem);
-        });
+        scenario.onFragment(
+                fragment -> {
+                    org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                            new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                    fragment.onMenuItemSelected(resetMenuItem);
+                });
 
-        // 4. Verify we are back on the setup screen and inputs are prefilled with last-used values (3 and 30)
-        scenario.onFragment(fragment -> {
-            View view = fragment.getView();
-            View setupContent = view.findViewById(R.id.setup_content);
-            assertEquals(View.VISIBLE, setupContent.getVisibility());
+        // 4. Verify we are back on the setup screen and inputs are prefilled with last-used values
+        // (3 and 30)
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    View setupContent = view.findViewById(R.id.setup_content);
+                    assertEquals(View.VISIBLE, setupContent.getVisibility());
 
-            View boardContainer = view.findViewById(R.id.board_container);
-            assertEquals(View.GONE, boardContainer.getVisibility());
+                    View boardContainer = view.findViewById(R.id.board_container);
+                    assertEquals(View.GONE, boardContainer.getVisibility());
 
-            EditText playersInput = view.findViewById(R.id.players_input);
-            EditText lifeInput = view.findViewById(R.id.life_input);
-            assertEquals("3", playersInput.getText().toString());
-            assertEquals("30", lifeInput.getText().toString());
-        });
+                    EditText playersInput = view.findViewById(R.id.players_input);
+                    EditText lifeInput = view.findViewById(R.id.life_input);
+                    assertEquals("3", playersInput.getText().toString());
+                    assertEquals("30", lifeInput.getText().toString());
+                });
     }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -117,4 +117,61 @@ public class MtgLifeFragmentTest {
             assertEquals("39", life2.getText().toString());
         });
     }
+
+    @Test
+    public void testNewGameResetActionReturnsToSetupWithPrefilledValues() {
+        FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+
+        // 1. Enter non-default setup, e.g., 3 players, 30 life, and start game
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            EditText playersInput = view.findViewById(R.id.players_input);
+            EditText lifeInput = view.findViewById(R.id.life_input);
+            playersInput.setText("3");
+            lifeInput.setText("30");
+
+            Button startButton = view.findViewById(R.id.start_game_button);
+            startButton.performClick();
+        });
+
+        // 2. Verify we are playing 3 players game
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            View setupContent = view.findViewById(R.id.setup_content);
+            assertEquals(View.GONE, setupContent.getVisibility());
+
+            View boardContainer = view.findViewById(R.id.board_container);
+            assertEquals(View.VISIBLE, boardContainer.getVisibility());
+
+            View player1 = view.findViewById(R.id.player_1);
+            View player3 = view.findViewById(R.id.player_3);
+            assertNotNull(player1);
+            assertNotNull(player3);
+
+            TextView life1 = player1.findViewById(R.id.tv_life_count);
+            assertEquals("30", life1.getText().toString());
+        });
+
+        // 3. Trigger app-bar "New Game" menu action (action_new_game)
+        scenario.onFragment(fragment -> {
+            org.robolectric.fakes.RoboMenuItem resetMenuItem = new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+            fragment.onMenuItemSelected(resetMenuItem);
+        });
+
+        // 4. Verify we are back on the setup screen and inputs are prefilled with last-used values (3 and 30)
+        scenario.onFragment(fragment -> {
+            View view = fragment.getView();
+            View setupContent = view.findViewById(R.id.setup_content);
+            assertEquals(View.VISIBLE, setupContent.getVisibility());
+
+            View boardContainer = view.findViewById(R.id.board_container);
+            assertEquals(View.GONE, boardContainer.getVisibility());
+
+            EditText playersInput = view.findViewById(R.id.players_input);
+            EditText lifeInput = view.findViewById(R.id.life_input);
+            assertEquals("3", playersInput.getText().toString());
+            assertEquals("30", lifeInput.getText().toString());
+        });
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -93,12 +93,12 @@ public class MtgLifeFragmentTest {
             assertEquals("40", life1.getText().toString());
             assertEquals("40", life2.getText().toString());
 
-            // Tap R.id.btn_plus for player 1
-            View btnPlus1 = player1.findViewById(R.id.btn_plus);
+            // Tap PLUS button for player 1 (which maps to R.id.btn_minus for 90-degree rotated seat)
+            View btnPlus1 = player1.findViewById(R.id.btn_minus);
             assertNotNull(btnPlus1);
             btnPlus1.performClick();
 
-            // Tap R.id.btn_minus for player 2
+            // Tap MINUS button for player 2 (which maps to R.id.btn_minus for 270-degree rotated seat)
             View btnMinus2 = player2.findViewById(R.id.btn_minus);
             assertNotNull(btnMinus2);
             btnMinus2.performClick();

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -183,14 +183,14 @@ public class MtgLifeViewModelTest {
         assertEquals(270, state.getPlayers().get(3).getRotationDegrees());
         assertEquals(0, state.getPlayers().get(4).getRotationDegrees());
 
-        // 6 Players
+        // 6 Players (2 wide, 3 tall lateral split grid)
         viewModel.validateAndStartGame("6", "40");
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(90, state.getPlayers().get(0).getRotationDegrees());
-        assertEquals(180, state.getPlayers().get(1).getRotationDegrees());
-        assertEquals(270, state.getPlayers().get(2).getRotationDegrees());
-        assertEquals(90, state.getPlayers().get(3).getRotationDegrees());
-        assertEquals(0, state.getPlayers().get(4).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(1).getRotationDegrees());
+        assertEquals(90, state.getPlayers().get(2).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(3).getRotationDegrees());
+        assertEquals(90, state.getPlayers().get(4).getRotationDegrees());
         assertEquals(270, state.getPlayers().get(5).getRotationDegrees());
     }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -156,4 +156,41 @@ public class MtgLifeViewModelTest {
         assertEquals(21, state.getPlayers().get(0).getLifeTotal());
         assertEquals(19, state.getPlayers().get(1).getLifeTotal());
     }
+
+    @Test
+    public void testRotationsForVaryingPlayerCounts() throws Exception {
+        // 3 Players
+        viewModel.validateAndStartGame("3", "40");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(180, state.getPlayers().get(0).getRotationDegrees());
+        assertEquals(90, state.getPlayers().get(1).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(2).getRotationDegrees());
+
+        // 4 Players (Lateral orientation matching the user specifications)
+        viewModel.validateAndStartGame("4", "40");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(90, state.getPlayers().get(0).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(1).getRotationDegrees());
+        assertEquals(90, state.getPlayers().get(2).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(3).getRotationDegrees());
+
+        // 5 Players (4-player lateral grid + full width bottom 0-degree player)
+        viewModel.validateAndStartGame("5", "40");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(90, state.getPlayers().get(0).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(1).getRotationDegrees());
+        assertEquals(90, state.getPlayers().get(2).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(3).getRotationDegrees());
+        assertEquals(0, state.getPlayers().get(4).getRotationDegrees());
+
+        // 6 Players
+        viewModel.validateAndStartGame("6", "40");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(90, state.getPlayers().get(0).getRotationDegrees());
+        assertEquals(180, state.getPlayers().get(1).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(2).getRotationDegrees());
+        assertEquals(90, state.getPlayers().get(3).getRotationDegrees());
+        assertEquals(0, state.getPlayers().get(4).getRotationDegrees());
+        assertEquals(270, state.getPlayers().get(5).getRotationDegrees());
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -7,10 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.SavedStateHandle;
-
 import com.nicue.onetwo.LiveDataTestUtil;
 import com.nicue.onetwo.R;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,8 +20,7 @@ import org.robolectric.annotation.Config;
 @Config(sdk = 34)
 public class MtgLifeViewModelTest {
 
-    @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     private MtgLifeViewModel viewModel;
 

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -1,0 +1,159 @@
+package com.nicue.onetwo.ui.life;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.SavedStateHandle;
+
+import com.nicue.onetwo.LiveDataTestUtil;
+import com.nicue.onetwo.R;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class MtgLifeViewModelTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    private MtgLifeViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        viewModel = new MtgLifeViewModel(new SavedStateHandle());
+    }
+
+    @Test
+    public void testDefaultSetupState() throws Exception {
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertEquals(4, state.getPlayerCount());
+        assertEquals(40, state.getStartingLife());
+        assertNull(state.getPlayersErrorResId());
+        assertNull(state.getLifeErrorResId());
+        assertTrue(state.getPlayers().isEmpty());
+    }
+
+    @Test
+    public void testSuccessfulValidationAndGameStart() throws Exception {
+        viewModel.validateAndStartGame("2", "20");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+
+        assertFalse(state.isShowingSetup());
+        assertEquals(2, state.getPlayerCount());
+        assertEquals(20, state.getStartingLife());
+        assertNull(state.getPlayersErrorResId());
+        assertNull(state.getLifeErrorResId());
+
+        assertEquals(2, state.getPlayers().size());
+        assertEquals(0, state.getPlayers().get(0).getSeatIndex());
+        assertEquals(20, state.getPlayers().get(0).getLifeTotal());
+        assertEquals(1, state.getPlayers().get(1).getSeatIndex());
+        assertEquals(20, state.getPlayers().get(1).getLifeTotal());
+    }
+
+    @Test
+    public void testPlayerCountValidationError() throws Exception {
+        // Less than 1 player
+        viewModel.validateAndStartGame("0", "20");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertEquals(R.string.mtg_setup_players_error, (int) state.getPlayersErrorResId());
+        assertNull(state.getLifeErrorResId());
+
+        // More than 6 players
+        viewModel.validateAndStartGame("7", "20");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertEquals(R.string.mtg_setup_players_error, (int) state.getPlayersErrorResId());
+        assertNull(state.getLifeErrorResId());
+
+        // Non-integer player count
+        viewModel.validateAndStartGame("abc", "20");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertEquals(R.string.mtg_setup_players_error, (int) state.getPlayersErrorResId());
+        assertNull(state.getLifeErrorResId());
+    }
+
+    @Test
+    public void testLifeTotalValidationError() throws Exception {
+        // Less than or equal to 0 life
+        viewModel.validateAndStartGame("4", "0");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertNull(state.getPlayersErrorResId());
+        assertEquals(R.string.mtg_setup_life_error, (int) state.getLifeErrorResId());
+
+        // Negative life
+        viewModel.validateAndStartGame("4", "-5");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertNull(state.getPlayersErrorResId());
+        assertEquals(R.string.mtg_setup_life_error, (int) state.getLifeErrorResId());
+
+        // Non-integer life
+        viewModel.validateAndStartGame("4", "xyz");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertNull(state.getPlayersErrorResId());
+        assertEquals(R.string.mtg_setup_life_error, (int) state.getLifeErrorResId());
+    }
+
+    @Test
+    public void testBothFieldsValidationError() throws Exception {
+        viewModel.validateAndStartGame("10", "0");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertEquals(R.string.mtg_setup_players_error, (int) state.getPlayersErrorResId());
+        assertEquals(R.string.mtg_setup_life_error, (int) state.getLifeErrorResId());
+    }
+
+    @Test
+    public void testResetClearsErrorsAndShowsSetup() throws Exception {
+        // Generate validation errors first
+        viewModel.validateAndStartGame("10", "0");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(R.string.mtg_setup_players_error, (int) state.getPlayersErrorResId());
+        assertEquals(R.string.mtg_setup_life_error, (int) state.getLifeErrorResId());
+
+        // Start game successfully
+        viewModel.validateAndStartGame("2", "20");
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.isShowingSetup());
+
+        // Reset to setup
+        viewModel.resetToSetup();
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertNull(state.getPlayersErrorResId());
+        assertNull(state.getLifeErrorResId());
+    }
+
+    @Test
+    public void testIncrementAndDecrementLife() throws Exception {
+        viewModel.validateAndStartGame("2", "20");
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+
+        // Increment player 0 life
+        viewModel.incrementLife(0);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(21, state.getPlayers().get(0).getLifeTotal());
+        assertEquals(20, state.getPlayers().get(1).getLifeTotal());
+
+        // Decrement player 1 life
+        viewModel.decrementLife(1);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(21, state.getPlayers().get(0).getLifeTotal());
+        assertEquals(19, state.getPlayers().get(1).getLifeTotal());
+    }
+}

--- a/docs/rfcs/2026-05-18-mtg-life-counter-fragment.md
+++ b/docs/rfcs/2026-05-18-mtg-life-counter-fragment.md
@@ -1,0 +1,291 @@
+# RFC: MTG Life Counter Fragment
+
+- Status: Proposed
+- Date: 2026-05-18
+
+## Summary
+
+Add a new top-level MTG life counter fragment to OneTwo. The feature starts on a setup screen with `New Game`, `Players`, and `Life` inputs, defaulting to 4 players and 40 life. Starting a game transitions in-place to a shared-screen life board that supports 1 to 6 players, uses OneTwo colors, and updates each player total by exactly `-1` or `+1` per tap.
+
+## Motivation
+
+The existing counter screen works for generic counters but is not optimized for a shared Magic: The Gathering play surface. MTG games need:
+
+- fast game setup
+- large readable life totals
+- layouts that work when a phone is placed on the table
+- fixed `+1` and `-1` interactions without opening dialogs
+
+This feature should feel purpose-built instead of asking users to create and manage multiple generic counters manually.
+
+## Goals
+
+- Add a new fragment dedicated to MTG life tracking.
+- Support 1 to 6 players.
+- Default setup to 4 players and 40 life.
+- Show a setup state first, then a play state after pressing start.
+- Use large life totals and single-tap `+` and `-` actions.
+- Match OneTwo theming in light and dark mode.
+- Preserve in-progress game state across view recreation and configuration changes.
+
+## Non-Goals
+
+- Commander damage, poison, energy, experience, or other side counters
+- match history or undo history
+- persistent saved games in Room or SharedPreferences
+- tablet-specific layouts beyond what naturally scales from the phone-first design
+- custom increment values, gestures, or long-press acceleration in v1
+
+## Product Decision
+
+This should be a new top-level drawer destination, not a mode added onto the existing counter feature.
+
+Why:
+
+- the interaction model is substantially different from the generic counter list
+- the setup flow is MTG-specific
+- the play view is a full-screen shared board, not a scrolling list
+- keeping it separate avoids complicating `CounterFragment`, `CounterViewModel`, and Room data
+
+## UX Proposal
+
+### Setup State
+
+The fragment initially shows a centered setup surface inside the existing activity shell.
+
+- Title: `New Game`
+- Field 1: `Players`
+  - numeric input
+  - default `4`
+  - validation range `1..6`
+- Field 2: `Life`
+  - numeric input
+  - default `40`
+  - validation `> 0`
+- Primary CTA: `Start Game`
+
+Implementation notes:
+
+- Use `TextInputLayout` plus `TextInputEditText` to match existing patterns in the app.
+- Keep validation inline and non-blocking until `Start Game` is pressed.
+- If the user enters invalid data, show field errors instead of silently coercing values.
+
+### Play State
+
+After pressing `Start Game`, the same fragment swaps to a full-board play state.
+
+Each player panel contains:
+
+- a large life total centered in the tile
+- a minus affordance that decreases life by 1
+- a plus affordance that increases life by 1
+- a distinct background color derived from the app palette
+
+Behavior:
+
+- tapping minus decrements by exactly `1`
+- tapping plus increments by exactly `1`
+- no confirmation dialogs
+- no animations beyond standard Material press feedback in v1
+
+The board should fill the fragment content area below the existing toolbar. We should not special-case hiding the app bar in v1; the app currently uses a consistent top-level navigation shell and this feature should fit it.
+
+## Layout Strategy By Player Count
+
+Because the board must work from 1 to 6 players and some counts need asymmetric arrangements, we should use dedicated XML templates per player count rather than a generic `RecyclerView`.
+
+Proposed templates:
+
+| Players | Template | Notes |
+| --- | --- | --- |
+| 1 | single full-screen panel | upright text |
+| 2 | two stacked halves | top panel rotated 180, bottom upright |
+| 3 | one top half plus two bottom panels | top rotated 180, lower pair oriented to left/right edges |
+| 4 | 2x2 board | closest visual match to the provided reference |
+| 5 | two top panels plus three bottom panels | custom template to avoid an awkward empty slot |
+| 6 | 2x3 board | top row rotated 180, bottom row upright |
+
+Rotation guideline:
+
+- top-facing seats: `180`
+- bottom-facing seats: `0`
+- left-facing seats: `270`
+- right-facing seats: `90`
+
+This preserves the shared-table feeling for lower player counts while keeping 5- and 6-player support practical on a phone.
+
+## Visual Design
+
+The provided reference is the right interaction model, but the colors should be clearly OneTwo.
+
+Recommended approach:
+
+- define dedicated player tile colors in `values/colors.xml` and `values-night/colors.xml`
+- derive them from the existing blue, gold, and red palette rather than importing unrelated neon colors
+- pair each tile color with an explicit foreground color for contrast
+
+Suggested palette direction:
+
+- player 1: primary container family
+- player 2: secondary container family
+- player 3: tertiary container family
+- player 4: primary or secondary tonal variant
+- player 5: tertiary tonal variant
+- player 6: darker supporting neutral or accent variant
+
+The exact values can be tuned during implementation, but the RFC decision is to introduce explicit `lifeCounterPlayerX` and `lifeCounterOnPlayerX` color resources instead of reusing unrelated dice colors.
+
+## Architecture
+
+### Navigation
+
+Add a new top-level destination:
+
+- `nav_mtg_life` in `app/src/main/res/navigation/main_nav_graph.xml`
+- matching drawer item in `app/src/main/res/menu/drawer_view.xml`
+- matching entry in `MainActivity` `AppBarConfiguration`
+- new localized strings in `values/strings.xml` and `values-es/strings.xml`
+
+Menu label recommendation: `Life Counter`
+
+### Package and Files
+
+Recommended package:
+
+- `app/src/main/java/com/nicue/onetwo/ui/life/`
+
+Initial file set:
+
+- `MtgLifeFragment.java`
+- `MtgLifeViewModel.java`
+- `MtgLifeUiState.java`
+- `LifePlayerUiModel.java`
+- `MtgLifeViewModelFactory.java` only if needed by the chosen state approach
+
+Initial resource set:
+
+- `app/src/main/res/layout/life_fragment.xml`
+- `app/src/main/res/layout/life_setup_content.xml`
+- `app/src/main/res/layout/life_board_1.xml`
+- `app/src/main/res/layout/life_board_2.xml`
+- `app/src/main/res/layout/life_board_3.xml`
+- `app/src/main/res/layout/life_board_4.xml`
+- `app/src/main/res/layout/life_board_5.xml`
+- `app/src/main/res/layout/life_board_6.xml`
+- `app/src/main/res/menu/life_actions.xml` for an app-bar `New Game` action
+
+### State Management
+
+This feature does not need Room or SharedPreferences in v1.
+
+Use a `ViewModel` with in-memory state backed by `SavedStateHandle` so that:
+
+- the game survives configuration changes
+- the fragment can recreate its view without losing scores
+- process recreation has a straightforward restoration path
+
+Recommended state model:
+
+- `boolean showingSetup`
+- `int playerCount`
+- `int startingLife`
+- `List<Integer> currentLives`
+
+Recommended UI model:
+
+- `MtgLifeUiState`
+  - `showingSetup`
+  - `playerCount`
+  - `startingLife`
+  - `List<LifePlayerUiModel> players`
+
+- `LifePlayerUiModel`
+  - `seatIndex`
+  - `lifeTotal`
+  - `rotationDegrees`
+  - `backgroundColorRes`
+  - `foregroundColorRes`
+
+This keeps all game rules in the `ViewModel` and lets the fragment stay focused on binding clicks and rendering the active template.
+
+### Interaction Model
+
+Fragment responsibilities:
+
+- inflate binding
+- render setup or play state
+- route button taps to the `ViewModel`
+- inflate the correct board template for the current player count
+
+ViewModel responsibilities:
+
+- validate setup input
+- create a new game with the chosen player count and starting life
+- increment and decrement life totals
+- expose UI state as `LiveData`
+- reset back to setup on `New Game`
+
+Recommended reset behavior:
+
+- an app-bar `New Game` action returns to setup
+- setup fields stay prefilled with the last used values, not hard-reset to 4 and 40 every time
+
+That makes rematches faster while still honoring the required defaults for first launch.
+
+## Accessibility and Usability
+
+- plus and minus controls must keep at least 48dp touch targets
+- life totals should use auto-sizing text or per-template text sizes so 3-digit values remain readable
+- content descriptions should identify player number and action, for example `Decrease life for player 2`
+- color choices must meet contrast requirements in both `values` and `values-night`
+- layout should avoid relying on color alone for affordance; the `+` and `-` controls must remain explicit
+
+## Testing Plan
+
+Local JVM and Robolectric tests are sufficient for v1.
+
+Add:
+
+- `MtgLifeViewModelTest`
+  - defaults are 4 players and 40 life
+  - validation rejects players outside `1..6`
+  - validation rejects non-positive starting life
+  - starting a game creates the expected number of players
+  - increment and decrement only change the targeted player by 1
+  - `New Game` returns to setup and preserves last-used configuration
+
+- `MtgLifeFragmentTest`
+  - setup state is visible on first launch
+  - setup fields are prefilled with `4` and `40`
+  - starting a game swaps to the 4-player board
+  - tapping plus and minus updates visible totals
+
+- update `NavigationSmokeTest`
+  - verify `nav_mtg_life` is present and navigable
+
+## Implementation Plan
+
+1. Add navigation, drawer, strings, and the fragment shell.
+2. Implement the setup state and `MtgLifeViewModel`.
+3. Add the 1-6 player board templates and per-seat rendering.
+4. Add the app-bar `New Game` reset action.
+5. Add tests and polish colors for light and dark mode.
+
+## Risks and Mitigations
+
+- Small-screen density for 5 and 6 players
+  - Mitigation: dedicated templates, tight padding, and auto-sized life text
+- Dark mode contrast regressions
+  - Mitigation: explicit foreground color resources per tile, not implicit theme lookups
+- Overengineering state persistence
+  - Mitigation: keep v1 session-only and avoid database work unless a save/resume requirement appears later
+
+## Future Extensions
+
+Likely follow-ups if the feature lands well:
+
+- commander damage tracking
+- poison counters
+- random first player / turn order integration
+- per-player names
+- larger-table or tablet-specific layouts


### PR DESCRIPTION
## Summary
- Add a new top-level MTG life counter destination with drawer and navigation wiring.
- Introduce a setup flow for 1 to 6 players with default values of 4 players and 40 life.
- Render a full-board life counter experience with per-player `+1` and `-1` controls using OneTwo theming.
- Add supporting state models, layouts, and localized strings, plus an RFC for the feature.

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/bf694fc5-0848-4b27-ac06-94d89924b2b1" />


## Testing
- Added/updated unit and fragment tests for setup defaults, validation, game state changes, and navigation coverage.
- Ran local Gradle validation successfully, including unit tests and a debug build.