### PR TITLE
Add commander damage tracking to the MTG life counter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 27
-        versionName "1.8.0"
+        versionCode 28
+        versionName "1.8.1"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 26
-        versionName "1.7.1"
+        versionCode 27
+        versionName "1.8.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/CommanderDamageUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/CommanderDamageUiModel.java
@@ -1,0 +1,49 @@
+package com.nicue.onetwo.ui.life;
+
+public class CommanderDamageUiModel {
+    private final int sourceSeatIndex;
+    private final int amount;
+    private final boolean self;
+    private final boolean lethal;
+    private final int backgroundColorRes;
+    private final int foregroundColorRes;
+
+    public CommanderDamageUiModel(
+            int sourceSeatIndex,
+            int amount,
+            boolean self,
+            boolean lethal,
+            int backgroundColorRes,
+            int foregroundColorRes) {
+        this.sourceSeatIndex = sourceSeatIndex;
+        this.amount = amount;
+        this.self = self;
+        this.lethal = lethal;
+        this.backgroundColorRes = backgroundColorRes;
+        this.foregroundColorRes = foregroundColorRes;
+    }
+
+    public int getSourceSeatIndex() {
+        return sourceSeatIndex;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public boolean isSelf() {
+        return self;
+    }
+
+    public boolean isLethal() {
+        return lethal;
+    }
+
+    public int getBackgroundColorRes() {
+        return backgroundColorRes;
+    }
+
+    public int getForegroundColorRes() {
+        return foregroundColorRes;
+    }
+}

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -1,23 +1,31 @@
 package com.nicue.onetwo.ui.life;
 
+import java.util.List;
+
 public class LifePlayerUiModel {
     private final int seatIndex;
     private final int lifeTotal;
     private final int rotationDegrees;
     private final int backgroundColorRes;
     private final int foregroundColorRes;
+    private final boolean commanderDamageVisible;
+    private final List<CommanderDamageUiModel> commanderDamages;
 
     public LifePlayerUiModel(
             int seatIndex,
             int lifeTotal,
             int rotationDegrees,
             int backgroundColorRes,
-            int foregroundColorRes) {
+            int foregroundColorRes,
+            boolean commanderDamageVisible,
+            List<CommanderDamageUiModel> commanderDamages) {
         this.seatIndex = seatIndex;
         this.lifeTotal = lifeTotal;
         this.rotationDegrees = rotationDegrees;
         this.backgroundColorRes = backgroundColorRes;
         this.foregroundColorRes = foregroundColorRes;
+        this.commanderDamageVisible = commanderDamageVisible;
+        this.commanderDamages = commanderDamages;
     }
 
     public int getSeatIndex() {
@@ -38,5 +46,13 @@ public class LifePlayerUiModel {
 
     public int getForegroundColorRes() {
         return foregroundColorRes;
+    }
+
+    public boolean isCommanderDamageVisible() {
+        return commanderDamageVisible;
+    }
+
+    public List<CommanderDamageUiModel> getCommanderDamages() {
+        return commanderDamages;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -1,21 +1,36 @@
 package com.nicue.onetwo.ui.life;
 
+import android.app.Dialog;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
 import android.os.Bundle;
+import android.text.Editable;
+import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.view.MenuHost;
 import androidx.core.view.MenuProvider;
+import androidx.core.widget.TextViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.nicue.onetwo.R;
 import com.nicue.onetwo.databinding.LifeBoard1Binding;
 import com.nicue.onetwo.databinding.LifeBoard2Binding;
@@ -26,17 +41,22 @@ import com.nicue.onetwo.databinding.LifeBoard6Binding;
 import com.nicue.onetwo.databinding.LifeFragmentBinding;
 import com.nicue.onetwo.databinding.LifePlayerCellBinding;
 import com.nicue.onetwo.databinding.LifeSetupContentBinding;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MtgLifeFragment extends Fragment implements MenuProvider {
+    private static final int PREVIEW_PLAYER_COUNT = 4;
 
     private LifeFragmentBinding binding;
     private MtgLifeViewModel viewModel;
     private boolean inputsInitialized = false;
     private int currentBoardPlayerCount = -1;
     private Integer activeDialogDefenderSeatIndex = null;
-    private final java.util.Map<Integer, android.widget.TextView> activeDialogDamageTextViews = new java.util.HashMap<>();
+    private final Map<Integer, TextView> activeDialogDamageTextViews = new HashMap<>();
 
-    @Nullable @Override
+    @Nullable
+    @Override
     public View onCreateView(
             @NonNull LayoutInflater inflater,
             @Nullable ViewGroup container,
@@ -50,7 +70,6 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         super.onViewCreated(view, savedInstanceState);
 
         viewModel = new ViewModelProvider(this).get(MtgLifeViewModel.class);
-
         LifeSetupContentBinding setupBinding =
                 LifeSetupContentBinding.bind(binding.setupContent.getRoot());
 
@@ -60,379 +79,19 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         getViewLifecycleOwner(),
                         uiState -> {
                             requireActivity().invalidateOptionsMenu();
-
-                            if (activeDialogDefenderSeatIndex != null) {
-                                LifePlayerUiModel defender = null;
-                                for (LifePlayerUiModel p : uiState.getPlayers()) {
-                                    if (p.getSeatIndex() == activeDialogDefenderSeatIndex) {
-                                        defender = p;
-                                        break;
-                                    }
-                                }
-                                if (defender != null) {
-                                    for (CommanderDamageUiModel dmg : defender.getCommanderDamages()) {
-                                        android.widget.TextView tv = activeDialogDamageTextViews.get(dmg.getSourceSeatIndex());
-                                        if (tv != null) {
-                                            tv.setText(String.valueOf(dmg.getAmount()));
-                                            if (dmg.isLethal()) {
-                                                tv.setTextColor(ContextCompat.getColor(requireContext(), R.color.secondAccent));
-                                            } else {
-                                                Object tag = tv.getTag();
-                                                if (tag instanceof Integer) {
-                                                    tv.setTextColor((Integer) tag);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            syncActiveCommanderDamageDialog(uiState);
 
                             if (uiState.isShowingSetup()) {
-                                binding.setupOverlay.setVisibility(View.VISIBLE);
-                                binding.setupContent.getRoot().setVisibility(View.VISIBLE);
-                                if (binding.boardContainer.getChildCount() == 0) {
-                                    binding.boardContainer.removeAllViews();
-                                    LayoutInflater inflater = LayoutInflater.from(requireContext());
-                                    LifeBoard4Binding.inflate(
-                                            inflater, binding.boardContainer, true);
-                                    currentBoardPlayerCount = 4;
-
-                                    for (int i = 0; i < 4; i++) {
-                                        int seatId;
-                                        switch (i) {
-                                            case 0:
-                                                seatId = R.id.player_1;
-                                                break;
-                                            case 1:
-                                                seatId = R.id.player_2;
-                                                break;
-                                            case 2:
-                                                seatId = R.id.player_3;
-                                                break;
-                                            case 3:
-                                                seatId = R.id.player_4;
-                                                break;
-                                            default:
-                                                continue;
-                                        }
-                                        View cellView = binding.boardContainer.findViewById(seatId);
-                                        if (cellView != null) {
-                                            LifePlayerCellBinding cellBinding =
-                                                    LifePlayerCellBinding.bind(cellView);
-                                            int bgColorRes;
-                                            switch (i) {
-                                                case 0:
-                                                    bgColorRes = R.color.lifeCounterPlayer1;
-                                                    break;
-                                                case 1:
-                                                    bgColorRes = R.color.lifeCounterPlayer2;
-                                                    break;
-                                                case 2:
-                                                    bgColorRes = R.color.lifeCounterPlayer3;
-                                                    break;
-                                                case 3:
-                                                    bgColorRes = R.color.lifeCounterPlayer4;
-                                                    break;
-                                                default:
-                                                    bgColorRes = R.color.lifeCounterPlayer1;
-                                                    break;
-                                            }
-                                            int bgColor =
-                                                    ContextCompat.getColor(
-                                                            requireContext(), bgColorRes);
-                                            boolean isDark =
-                                                    ColorUtils.calculateLuminance(bgColor) < 0.5;
-                                            int fgColor = isDark ? 0xFFFFFFFF : 0xFF000000;
-
-                                            cellBinding.playerCellContainer.setBackgroundColor(
-                                                    bgColor);
-                                            cellBinding.tvLifeCount.setTextColor(fgColor);
-                                            cellBinding.tvLifeCount.setText(getString(R.string.default_mtg_life));
-
-                                            cellBinding.btnMinus.setIconTint(
-                                                    android.content.res.ColorStateList.valueOf(
-                                                            fgColor));
-                                            cellBinding.btnPlus.setIconTint(
-                                                    android.content.res.ColorStateList.valueOf(
-                                                            fgColor));
-
-                                            float rotation = (i % 2 == 0) ? 90f : 270f;
-                                            cellBinding.playerCellContainer.setRotation(0f);
-                                            cellBinding.innerPlayerLayout.setRotation(rotation);
-                                        }
-                                    }
-                                }
-                                binding.boardContainer.setVisibility(View.VISIBLE);
-
-                                if (!inputsInitialized) {
-                                    setupBinding.playersInput.setText(
-                                            String.valueOf(uiState.getPlayerCount()));
-                                    setupBinding.lifeInput.setText(
-                                            String.valueOf(uiState.getStartingLife()));
-                                    setupBinding.commanderDamageSwitch.setChecked(
-                                            uiState.isCommanderDamageEnabled());
-                                    inputsInitialized = true;
-                                }
-
-                                if (uiState.getPlayersErrorResId() != null) {
-                                    setupBinding.playersInputLayout.setError(
-                                            getString(uiState.getPlayersErrorResId()));
-                                } else {
-                                    setupBinding.playersInputLayout.setError(null);
-                                }
-
-                                if (uiState.getLifeErrorResId() != null) {
-                                    setupBinding.lifeInputLayout.setError(
-                                            getString(uiState.getLifeErrorResId()));
-                                } else {
-                                    setupBinding.lifeInputLayout.setError(null);
-                                }
+                                renderSetupState(uiState, setupBinding);
                             } else {
-                                binding.setupOverlay.setVisibility(View.GONE);
-                                binding.setupContent.getRoot().setVisibility(View.GONE);
-                                binding.boardContainer.setVisibility(View.VISIBLE);
-                                inputsInitialized = false;
-
-                                int playerCount = uiState.getPlayerCount();
-                                if (binding.boardContainer.getChildCount() == 0
-                                        || currentBoardPlayerCount != playerCount) {
-                                    binding.boardContainer.removeAllViews();
-                                    LayoutInflater inflater = LayoutInflater.from(requireContext());
-                                    currentBoardPlayerCount = playerCount;
-
-                                    switch (playerCount) {
-                                        case 1:
-                                            LifeBoard1Binding.inflate(
-                                                    inflater, binding.boardContainer, true);
-                                            break;
-                                        case 2:
-                                            LifeBoard2Binding.inflate(
-                                                    inflater, binding.boardContainer, true);
-                                            break;
-                                        case 3:
-                                            LifeBoard3Binding.inflate(
-                                                    inflater, binding.boardContainer, true);
-                                            break;
-                                        case 4:
-                                            LifeBoard4Binding.inflate(
-                                                    inflater, binding.boardContainer, true);
-                                            break;
-                                        case 5:
-                                            LifeBoard5Binding.inflate(
-                                                    inflater, binding.boardContainer, true);
-                                            break;
-                                        case 6:
-                                            LifeBoard6Binding.inflate(
-                                                    inflater, binding.boardContainer, true);
-                                            break;
-                                    }
-                                }
-
-                                // Bind player tiles
-                                for (int i = 0; i < playerCount; i++) {
-                                    int seatId;
-                                    switch (i) {
-                                        case 0:
-                                            seatId = R.id.player_1;
-                                            break;
-                                        case 1:
-                                            seatId = R.id.player_2;
-                                            break;
-                                        case 2:
-                                            seatId = R.id.player_3;
-                                            break;
-                                        case 3:
-                                            seatId = R.id.player_4;
-                                            break;
-                                        case 4:
-                                            seatId = R.id.player_5;
-                                            break;
-                                        case 5:
-                                            seatId = R.id.player_6;
-                                            break;
-                                        default:
-                                            continue;
-                                    }
-                                    View cellView = binding.boardContainer.findViewById(seatId);
-                                    if (cellView != null) {
-                                        LifePlayerCellBinding cellBinding =
-                                                LifePlayerCellBinding.bind(cellView);
-                                        LifePlayerUiModel player = uiState.getPlayers().get(i);
-
-                                        int maxSizeSp;
-                                        switch (playerCount) {
-                                            case 1:
-                                                maxSizeSp = 96;
-                                                break;
-                                            case 2:
-                                                maxSizeSp = 80;
-                                                break;
-                                            case 3:
-                                                maxSizeSp = 72;
-                                                break;
-                                            case 4:
-                                                maxSizeSp = 60;
-                                                break;
-                                            case 5:
-                                                maxSizeSp = 54;
-                                                break;
-                                            case 6:
-                                                maxSizeSp = 48;
-                                                break;
-                                            default:
-                                                maxSizeSp = 60;
-                                                break;
-                                        }
-                                        androidx.core.widget.TextViewCompat
-                                                .setAutoSizeTextTypeUniformWithConfiguration(
-                                                        cellBinding.tvLifeCount,
-                                                        20,
-                                                        maxSizeSp,
-                                                        2,
-                                                        android.util.TypedValue.COMPLEX_UNIT_SP);
-
-                                        cellBinding.tvLifeCount.setText(
-                                                String.valueOf(player.getLifeTotal()));
-                                        cellBinding.tvLifeCount.setContentDescription(
-                                                String.valueOf(player.getLifeTotal()));
-
-                                        int bgColor =
-                                                ContextCompat.getColor(
-                                                        requireContext(),
-                                                        player.getBackgroundColorRes());
-                                        boolean isDark =
-                                                ColorUtils.calculateLuminance(bgColor) < 0.5;
-                                        int fgColor = isDark ? 0xFFFFFFFF : 0xFF000000;
-
-                                        cellBinding.playerCellContainer.setBackgroundColor(bgColor);
-                                        cellBinding.tvLifeCount.setTextColor(fgColor);
-
-                                        cellBinding.btnMinus.setIconTint(
-                                                android.content.res.ColorStateList.valueOf(
-                                                        fgColor));
-                                        cellBinding.btnPlus.setIconTint(
-                                                android.content.res.ColorStateList.valueOf(
-                                                        fgColor));
-
-                                        final int seatIndex = player.getSeatIndex();
-                                        cellBinding.btnMinus.setOnClickListener(
-                                                v -> viewModel.decrementLife(seatIndex));
-                                        cellBinding.btnPlus.setOnClickListener(
-                                                v -> viewModel.incrementLife(seatIndex));
-
-                                        cellBinding.btnMinus.setContentDescription(
-                                                getString(
-                                                        R.string.mtg_btn_minus_desc,
-                                                        seatIndex + 1));
-                                        cellBinding.btnPlus.setContentDescription(
-                                                getString(
-                                                        R.string.mtg_btn_plus_desc, seatIndex + 1));
-
-                                        if (player.isCommanderDamageVisible()) {
-                                            cellBinding.commanderDamageGrid.setVisibility(View.VISIBLE);
-                                            cellBinding.commanderDamageGrid.removeAllViews();
-
-                                            int totalPlayers = uiState.getPlayerCount();
-                                            int rows = totalPlayers > 2 ? 2 : 1;
-                                            int cols = totalPlayers > 4 ? 3 : 2;
-
-                                            java.util.List<CommanderDamageUiModel> damages = player.getCommanderDamages();
-                                            for (int r = 0; r < rows; r++) {
-                                                android.widget.LinearLayout rowLayout = new android.widget.LinearLayout(requireContext());
-                                                rowLayout.setOrientation(android.widget.LinearLayout.HORIZONTAL);
-                                                android.widget.LinearLayout.LayoutParams rowParams = new android.widget.LinearLayout.LayoutParams(
-                                                        android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
-                                                        android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-                                                );
-                                                rowLayout.setLayoutParams(rowParams);
-
-                                                for (int c = 0; c < cols; c++) {
-                                                    int idx = r * cols + c;
-                                                    int targetSeat = getSourceSeatForGridSlot(idx, seatIndex, totalPlayers);
-                                                    if (targetSeat < damages.size()) {
-                                                        CommanderDamageUiModel damage = damages.get(targetSeat);
-                                                        android.widget.TextView cellViewText = new android.widget.TextView(requireContext());
-                                                        cellViewText.setGravity(android.view.Gravity.CENTER);
-                                                        cellViewText.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 10);
-                                                        cellViewText.setTypeface(null, android.graphics.Typeface.BOLD);
-
-                                                        if (damage.isSelf()) {
-                                                            cellViewText.setText(getString(R.string.mtg_commander_damage_self_label));
-                                                            cellViewText.setEnabled(false);
-                                                        } else {
-                                                            cellViewText.setText(String.valueOf(damage.getAmount()));
-                                                        }
-
-                                                        int cellBgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
-                                                        int cellFgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
-
-                                                        android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
-                                                        gd.setCornerRadius(4 * getResources().getDisplayMetrics().density);
-                                                        if (damage.isSelf()) {
-                                                            gd.setStroke((int) (1 * getResources().getDisplayMetrics().density), cellFgColor);
-                                                            gd.setColor(android.graphics.Color.TRANSPARENT);
-                                                        } else {
-                                                            gd.setColor(cellBgColor);
-                                                        }
-                                                        cellViewText.setBackground(gd);
-                                                        cellViewText.setTextColor(cellFgColor);
-
-                                                        android.widget.LinearLayout.LayoutParams params = new android.widget.LinearLayout.LayoutParams(
-                                                                0,
-                                                                (int) (16 * getResources().getDisplayMetrics().density),
-                                                                1f
-                                                        );
-                                                        int margin = (int) (2 * getResources().getDisplayMetrics().density);
-                                                        params.setMargins(margin, margin, margin, margin);
-                                                        cellViewText.setLayoutParams(params);
-
-                                                        if (!damage.isSelf()) {
-                                                            cellViewText.setContentDescription(getString(
-                                                                    R.string.mtg_commander_damage_cell_desc,
-                                                                    damage.getSourceSeatIndex() + 1,
-                                                                    seatIndex + 1,
-                                                                    damage.getAmount()
-                                                            ));
-                                                        } else {
-                                                            cellViewText.setContentDescription(getString(R.string.mtg_commander_damage_self_desc));
-                                                        }
-
-                                                        rowLayout.addView(cellViewText);
-                                                    } else {
-                                                        android.view.View spacer = new android.view.View(requireContext());
-                                                        android.widget.LinearLayout.LayoutParams params = new android.widget.LinearLayout.LayoutParams(
-                                                                0,
-                                                                (int) (16 * getResources().getDisplayMetrics().density),
-                                                                1f
-                                                        );
-                                                        int margin = (int) (2 * getResources().getDisplayMetrics().density);
-                                                        params.setMargins(margin, margin, margin, margin);
-                                                        spacer.setLayoutParams(params);
-                                                        spacer.setVisibility(android.view.View.INVISIBLE);
-                                                        rowLayout.addView(spacer);
-                                                    }
-                                                }
-                                                cellBinding.commanderDamageGrid.addView(rowLayout);
-                                            }
-
-                                            cellBinding.commanderDamageGrid.setOnClickListener(v -> showCommanderDamageDialog(seatIndex));
-                                            cellBinding.commanderDamageGrid.setContentDescription(getString(R.string.mtg_commander_damage_manage_desc, seatIndex + 1));
-                                        } else {
-                                            cellBinding.commanderDamageGrid.setVisibility(View.GONE);
-                                        }
-
-                                        float rotation = player.getRotationDegrees();
-                                        cellBinding.playerCellContainer.setRotation(0f);
-                                        cellBinding.innerPlayerLayout.setRotation(rotation);
-                                    }
-                                }
+                                renderGameState(uiState);
                             }
                         });
 
         setupBinding.startGameButton.setOnClickListener(
                 v -> {
-                    android.text.Editable playersText = setupBinding.playersInput.getText();
-                    android.text.Editable lifeText = setupBinding.lifeInput.getText();
+                    Editable playersText = setupBinding.playersInput.getText();
+                    Editable lifeText = setupBinding.lifeInput.getText();
                     String playersStr = playersText != null ? playersText.toString() : "";
                     String lifeStr = lifeText != null ? lifeText.toString() : "";
                     boolean commanderEnabled = setupBinding.commanderDamageSwitch.isChecked();
@@ -440,13 +99,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                 });
 
         binding.setupOverlay.setOnClickListener(v -> viewModel.dismissSetup());
-        setupBinding
-                .getRoot()
-                .setOnClickListener(
-                        v -> {
-                            // Intercept clicks inside the setup card to prevent dismissing the
-                            // modal
-                        });
+        setupBinding.getRoot().setOnClickListener(v -> {});
 
         MenuHost menuHost = requireActivity();
         menuHost.addMenuProvider(this, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
@@ -456,8 +109,9 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
         menuInflater.inflate(R.menu.life_actions, menu);
         MenuItem newGameItem = menu.findItem(R.id.action_new_game);
-        if (newGameItem != null && viewModel != null && viewModel.getUiState().getValue() != null) {
-            newGameItem.setVisible(!viewModel.getUiState().getValue().isShowingSetup());
+        MtgLifeUiState currentUiState = viewModel != null ? viewModel.getUiState().getValue() : null;
+        if (newGameItem != null && currentUiState != null) {
+            newGameItem.setVisible(!currentUiState.isShowingSetup());
         }
     }
 
@@ -470,346 +124,575 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         return false;
     }
 
+    private void syncActiveCommanderDamageDialog(MtgLifeUiState uiState) {
+        if (activeDialogDefenderSeatIndex == null) {
+            return;
+        }
+
+        LifePlayerUiModel defender = findPlayerBySeat(uiState.getPlayers(), activeDialogDefenderSeatIndex);
+        if (defender == null) {
+            return;
+        }
+
+        for (CommanderDamageUiModel damage : defender.getCommanderDamages()) {
+            TextView damageTextView = activeDialogDamageTextViews.get(damage.getSourceSeatIndex());
+            if (damageTextView == null) {
+                continue;
+            }
+
+            damageTextView.setText(String.valueOf(damage.getAmount()));
+            if (damage.isLethal()) {
+                damageTextView.setTextColor(
+                        ContextCompat.getColor(requireContext(), R.color.secondAccent));
+            } else {
+                Object tag = damageTextView.getTag();
+                if (tag instanceof Integer color) {
+                    damageTextView.setTextColor(color);
+                }
+            }
+        }
+    }
+
+    private void renderSetupState(
+            MtgLifeUiState uiState, LifeSetupContentBinding setupBinding) {
+        binding.setupOverlay.setVisibility(View.VISIBLE);
+        binding.setupContent.getRoot().setVisibility(View.VISIBLE);
+        binding.boardContainer.setVisibility(View.VISIBLE);
+
+        ensureBoardInflated(PREVIEW_PLAYER_COUNT);
+        bindPreviewBoard();
+
+        if (!inputsInitialized) {
+            setupBinding.playersInput.setText(String.valueOf(uiState.getPlayerCount()));
+            setupBinding.lifeInput.setText(String.valueOf(uiState.getStartingLife()));
+            setupBinding.commanderDamageSwitch.setChecked(uiState.isCommanderDamageEnabled());
+            inputsInitialized = true;
+        }
+
+        setupBinding.playersInputLayout.setError(
+                uiState.getPlayersErrorResId() != null
+                        ? getString(uiState.getPlayersErrorResId())
+                        : null);
+        setupBinding.lifeInputLayout.setError(
+                uiState.getLifeErrorResId() != null
+                        ? getString(uiState.getLifeErrorResId())
+                        : null);
+    }
+
+    private void renderGameState(MtgLifeUiState uiState) {
+        binding.setupOverlay.setVisibility(View.GONE);
+        binding.setupContent.getRoot().setVisibility(View.GONE);
+        binding.boardContainer.setVisibility(View.VISIBLE);
+        inputsInitialized = false;
+
+        ensureBoardInflated(uiState.getPlayerCount());
+        bindGameBoard(uiState);
+    }
+
+    private void ensureBoardInflated(int playerCount) {
+        if (binding.boardContainer.getChildCount() != 0 && currentBoardPlayerCount == playerCount) {
+            return;
+        }
+
+        binding.boardContainer.removeAllViews();
+        LayoutInflater inflater = LayoutInflater.from(requireContext());
+        currentBoardPlayerCount = playerCount;
+
+        switch (playerCount) {
+            case 1 -> LifeBoard1Binding.inflate(inflater, binding.boardContainer, true);
+            case 2 -> LifeBoard2Binding.inflate(inflater, binding.boardContainer, true);
+            case 3 -> LifeBoard3Binding.inflate(inflater, binding.boardContainer, true);
+            case 4 -> LifeBoard4Binding.inflate(inflater, binding.boardContainer, true);
+            case 5 -> LifeBoard5Binding.inflate(inflater, binding.boardContainer, true);
+            case 6 -> LifeBoard6Binding.inflate(inflater, binding.boardContainer, true);
+            default -> throw new IllegalArgumentException("Unsupported player count: " + playerCount);
+        }
+    }
+
+    private void bindPreviewBoard() {
+        for (int seatIndex = 0; seatIndex < PREVIEW_PLAYER_COUNT; seatIndex++) {
+            View seatView = binding.boardContainer.findViewById(getSeatViewId(seatIndex));
+            if (seatView == null) {
+                continue;
+            }
+
+            LifePlayerCellBinding cellBinding = LifePlayerCellBinding.bind(seatView);
+            int backgroundColor =
+                    ContextCompat.getColor(
+                            requireContext(), getPreviewBackgroundColorRes(seatIndex));
+            int foregroundColor = getForegroundColor(backgroundColor);
+
+            cellBinding.playerCellContainer.setBackgroundColor(backgroundColor);
+            cellBinding.tvLifeCount.setText(getString(R.string.default_mtg_life));
+            cellBinding.tvLifeCount.setTextColor(foregroundColor);
+            cellBinding.btnMinus.setIconTint(ColorStateList.valueOf(foregroundColor));
+            cellBinding.btnPlus.setIconTint(ColorStateList.valueOf(foregroundColor));
+            cellBinding.commanderDamageGrid.setVisibility(View.GONE);
+            cellBinding.playerCellContainer.setRotation(0f);
+            cellBinding.innerPlayerLayout.setRotation(seatIndex % 2 == 0 ? 90f : 270f);
+        }
+    }
+
+    private void bindGameBoard(MtgLifeUiState uiState) {
+        int playerCount = uiState.getPlayerCount();
+        for (int seatIndex = 0; seatIndex < playerCount; seatIndex++) {
+            View seatView = binding.boardContainer.findViewById(getSeatViewId(seatIndex));
+            if (seatView == null) {
+                continue;
+            }
+
+            LifePlayerCellBinding cellBinding = LifePlayerCellBinding.bind(seatView);
+            bindPlayerCell(cellBinding, uiState.getPlayers().get(seatIndex), playerCount);
+        }
+    }
+
+    private void bindPlayerCell(
+            LifePlayerCellBinding cellBinding, LifePlayerUiModel player, int playerCount) {
+        int backgroundColor =
+                ContextCompat.getColor(requireContext(), player.getBackgroundColorRes());
+        int foregroundColor = getForegroundColor(backgroundColor);
+        int seatIndex = player.getSeatIndex();
+
+        TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+                cellBinding.tvLifeCount,
+                20,
+                getLifeCountMaxSizeSp(playerCount),
+                2,
+                TypedValue.COMPLEX_UNIT_SP);
+
+        cellBinding.tvLifeCount.setText(String.valueOf(player.getLifeTotal()));
+        cellBinding.tvLifeCount.setContentDescription(String.valueOf(player.getLifeTotal()));
+        cellBinding.tvLifeCount.setTextColor(foregroundColor);
+        cellBinding.playerCellContainer.setBackgroundColor(backgroundColor);
+
+        cellBinding.btnMinus.setIconTint(ColorStateList.valueOf(foregroundColor));
+        cellBinding.btnPlus.setIconTint(ColorStateList.valueOf(foregroundColor));
+        cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
+        cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+        cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
+        cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+
+        bindCommanderDamageSummary(cellBinding, player, playerCount);
+
+        cellBinding.playerCellContainer.setRotation(0f);
+        cellBinding.innerPlayerLayout.setRotation(player.getRotationDegrees());
+    }
+
+    private void bindCommanderDamageSummary(
+            LifePlayerCellBinding cellBinding, LifePlayerUiModel player, int totalPlayers) {
+        if (!player.isCommanderDamageVisible()) {
+            cellBinding.commanderDamageGrid.setVisibility(View.GONE);
+            cellBinding.commanderDamageGrid.setOnClickListener(null);
+            return;
+        }
+
+        cellBinding.commanderDamageGrid.setVisibility(View.VISIBLE);
+        cellBinding.commanderDamageGrid.removeAllViews();
+
+        int rows = getCommanderGridRowCount(totalPlayers);
+        int cols = getCommanderGridColumnCount(totalPlayers);
+        List<CommanderDamageUiModel> damages = player.getCommanderDamages();
+        int seatIndex = player.getSeatIndex();
+
+        for (int rowIndex = 0; rowIndex < rows; rowIndex++) {
+            LinearLayout rowLayout = new LinearLayout(requireContext());
+            rowLayout.setOrientation(LinearLayout.HORIZONTAL);
+            rowLayout.setLayoutParams(
+                    new LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT));
+
+            for (int columnIndex = 0; columnIndex < cols; columnIndex++) {
+                int slotIndex = rowIndex * cols + columnIndex;
+                int sourceSeatIndex =
+                        getSourceSeatForGridSlot(slotIndex, seatIndex, totalPlayers);
+                if (sourceSeatIndex < damages.size()) {
+                    rowLayout.addView(createCommanderSummaryCell(damages.get(sourceSeatIndex), seatIndex));
+                } else {
+                    rowLayout.addView(createCommanderSummarySpacer());
+                }
+            }
+
+            cellBinding.commanderDamageGrid.addView(rowLayout);
+        }
+
+        cellBinding.commanderDamageGrid.setOnClickListener(v -> showCommanderDamageDialog(seatIndex));
+        cellBinding.commanderDamageGrid.setContentDescription(
+                getString(R.string.mtg_commander_damage_manage_desc, seatIndex + 1));
+    }
+
+    private View createCommanderSummaryCell(
+            CommanderDamageUiModel damage, int defenderSeatIndex) {
+        TextView summaryCell = new TextView(requireContext());
+        summaryCell.setGravity(Gravity.CENTER);
+        summaryCell.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);
+        summaryCell.setTypeface(null, Typeface.BOLD);
+        summaryCell.setLayoutParams(createSmallGridLayoutParams(16));
+
+        if (damage.isSelf()) {
+            summaryCell.setVisibility(View.INVISIBLE);
+            return summaryCell;
+        }
+
+        summaryCell.setText(String.valueOf(damage.getAmount()));
+
+        int backgroundColor =
+                ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
+        int foregroundColor =
+                ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
+
+        GradientDrawable background = new GradientDrawable();
+        background.setCornerRadius(dpToPx(4));
+        background.setColor(backgroundColor);
+        summaryCell.setBackground(background);
+        summaryCell.setTextColor(foregroundColor);
+        summaryCell.setContentDescription(
+                getString(
+                        R.string.mtg_commander_damage_cell_desc,
+                        damage.getSourceSeatIndex() + 1,
+                        defenderSeatIndex + 1,
+                        damage.getAmount()));
+
+        return summaryCell;
+    }
+
+    private View createCommanderSummarySpacer() {
+        View spacer = new View(requireContext());
+        spacer.setLayoutParams(createSmallGridLayoutParams(16));
+        spacer.setVisibility(View.INVISIBLE);
+        return spacer;
+    }
+
+    private LinearLayout.LayoutParams createSmallGridLayoutParams(int heightDp) {
+        LinearLayout.LayoutParams params =
+                new LinearLayout.LayoutParams(0, dpToPx(heightDp), 1f);
+        int margin = dpToPx(2);
+        params.setMargins(margin, margin, margin, margin);
+        return params;
+    }
+
     private void showCommanderDamageDialog(int defenderSeatIndex) {
         activeDialogDefenderSeatIndex = defenderSeatIndex;
         activeDialogDamageTextViews.clear();
 
         MtgLifeUiState uiState = viewModel.getUiState().getValue();
-        if (uiState == null) return;
-
-        LifePlayerUiModel defender = null;
-        for (LifePlayerUiModel p : uiState.getPlayers()) {
-            if (p.getSeatIndex() == defenderSeatIndex) {
-                defender = p;
-                break;
-            }
+        if (uiState == null) {
+            return;
         }
-        if (defender == null) return;
 
-        com.google.android.material.dialog.MaterialAlertDialogBuilder builder =
-                new com.google.android.material.dialog.MaterialAlertDialogBuilder(requireContext());
+        LifePlayerUiModel defender = findPlayerBySeat(uiState.getPlayers(), defenderSeatIndex);
+        if (defender == null) {
+            return;
+        }
 
         int totalPlayers = uiState.getPlayerCount();
-        int rows = totalPlayers > 2 ? 2 : 1;
-        int cols = totalPlayers > 4 ? 3 : 2;
+        int rows = getCommanderGridRowCount(totalPlayers);
+        int cols = getCommanderGridColumnCount(totalPlayers);
 
-        android.widget.FrameLayout dialogRoot = new android.widget.FrameLayout(requireContext());
-        android.widget.FrameLayout.LayoutParams rootParams = new android.widget.FrameLayout.LayoutParams(
-                android.widget.FrameLayout.LayoutParams.MATCH_PARENT,
-                android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
-        );
-        dialogRoot.setLayoutParams(rootParams);
+        FrameLayout dialogRoot = new FrameLayout(requireContext());
+        dialogRoot.setLayoutParams(
+                new FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT));
 
-        int squareDimDp = (rows == 1) ? 176 : 228;
-        int squareDim = (int) (squareDimDp * getResources().getDisplayMetrics().density);
-        
-        android.widget.FrameLayout gridSquare = new android.widget.FrameLayout(requireContext());
-        android.widget.FrameLayout.LayoutParams squareParams = new android.widget.FrameLayout.LayoutParams(
-                squareDim, squareDim
-        );
-        squareParams.gravity = android.view.Gravity.CENTER;
-        gridSquare.setLayoutParams(squareParams);
-        gridSquare.setRotation(defender.getRotationDegrees());
+        FrameLayout rotatedGrid = new FrameLayout(requireContext());
+        FrameLayout.LayoutParams rotatedGridParams =
+                new FrameLayout.LayoutParams(
+                        dpToPx(rows == 1 ? 176 : 228), dpToPx(rows == 1 ? 176 : 228));
+        rotatedGridParams.gravity = Gravity.CENTER;
+        rotatedGrid.setLayoutParams(rotatedGridParams);
+        rotatedGrid.setRotation(defender.getRotationDegrees());
 
-        android.widget.LinearLayout container = new android.widget.LinearLayout(requireContext());
-        container.setOrientation(android.widget.LinearLayout.VERTICAL);
-        container.setGravity(android.view.Gravity.CENTER);
-        
-        android.graphics.drawable.GradientDrawable containerBg = new android.graphics.drawable.GradientDrawable();
-        containerBg.setColor(0xE61A1A1A); // Translucent near-black background
-        containerBg.setCornerRadius(10 * getResources().getDisplayMetrics().density);
-        container.setBackground(containerBg);
-        
-        int pad = (int) (4 * getResources().getDisplayMetrics().density);
-        container.setPadding(pad, pad, pad, pad);
+        LinearLayout dialogContent = new LinearLayout(requireContext());
+        dialogContent.setOrientation(LinearLayout.VERTICAL);
+        dialogContent.setGravity(Gravity.CENTER);
+        dialogContent.setPadding(dpToPx(4), dpToPx(4), dpToPx(4), dpToPx(4));
+        dialogContent.setBackground(createDialogBackground());
+        dialogContent.setLayoutParams(
+                new FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        Gravity.CENTER));
 
-        android.widget.FrameLayout.LayoutParams containerParams = new android.widget.FrameLayout.LayoutParams(
-                android.widget.FrameLayout.LayoutParams.MATCH_PARENT,
-                android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
-        );
-        containerParams.gravity = android.view.Gravity.CENTER;
-        container.setLayoutParams(containerParams);
+        List<CommanderDamageUiModel> damages = defender.getCommanderDamages();
+        for (int rowIndex = 0; rowIndex < rows; rowIndex++) {
+            LinearLayout rowLayout = new LinearLayout(requireContext());
+            rowLayout.setOrientation(LinearLayout.HORIZONTAL);
+            rowLayout.setLayoutParams(
+                    new LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT));
 
-        java.util.List<CommanderDamageUiModel> damages = defender.getCommanderDamages();
-        for (int r = 0; r < rows; r++) {
-            android.widget.LinearLayout rowLayout = new android.widget.LinearLayout(requireContext());
-            rowLayout.setOrientation(android.widget.LinearLayout.HORIZONTAL);
-            android.widget.LinearLayout.LayoutParams rowParams = new android.widget.LinearLayout.LayoutParams(
-                    android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
-                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-            );
-            rowLayout.setLayoutParams(rowParams);
-
-            for (int c = 0; c < cols; c++) {
-                int idx = r * cols + c;
-                int targetSeat = getSourceSeatForGridSlot(idx, defenderSeatIndex, totalPlayers);
-                if (targetSeat < damages.size()) {
-                    CommanderDamageUiModel damage = damages.get(targetSeat);
-                    
-                    android.widget.FrameLayout cellLayout =
-                            new android.widget.FrameLayout(requireContext());
-                    cellLayout.setClipToOutline(true);
-                    
-                    int cellBgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
-                    int cellFgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
-
-                    android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
-                    gd.setCornerRadius(8 * getResources().getDisplayMetrics().density);
-                    if (damage.isSelf()) {
-                        gd.setStroke((int) (1.5f * getResources().getDisplayMetrics().density), cellFgColor);
-                        gd.setColor(android.graphics.Color.TRANSPARENT);
-                    } else {
-                        gd.setColor(cellBgColor);
-                    }
-                    cellLayout.setBackground(gd);
-
-                    android.widget.LinearLayout.LayoutParams cellParams = new android.widget.LinearLayout.LayoutParams(
-                            0,
-                            (int) (64 * getResources().getDisplayMetrics().density),
-                            1f
-                    );
-                    int margin = (int) (4 * getResources().getDisplayMetrics().density);
-                    cellParams.setMargins(margin, margin, margin, margin);
-                    cellLayout.setLayoutParams(cellParams);
-
-                    if (damage.isSelf()) {
-                        android.widget.TextView selfTv = new android.widget.TextView(requireContext());
-                        selfTv.setGravity(android.view.Gravity.CENTER);
-                        selfTv.setText(getString(R.string.mtg_commander_damage_self_label));
-                        selfTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 18);
-                        selfTv.setTypeface(null, android.graphics.Typeface.BOLD);
-                        selfTv.setTextColor(cellFgColor);
-                        selfTv.setEnabled(false);
-                        
-                        android.widget.LinearLayout.LayoutParams selfParams = new android.widget.LinearLayout.LayoutParams(
-                                android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
-                                android.widget.LinearLayout.LayoutParams.MATCH_PARENT
-                        );
-                        selfTv.setLayoutParams(selfParams);
-                        cellLayout.addView(selfTv);
-                    } else {
-                        int sourceSeat = damage.getSourceSeatIndex();
-                        android.widget.TextView valTv = new android.widget.TextView(requireContext());
-                        valTv.setText(String.valueOf(damage.getAmount()));
-                        valTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 20);
-                        valTv.setTypeface(null, android.graphics.Typeface.BOLD);
-                        valTv.setGravity(android.view.Gravity.CENTER);
-                        valTv.setTextColor(cellFgColor);
-                        
-                        android.widget.FrameLayout.LayoutParams valParams =
-                                new android.widget.FrameLayout.LayoutParams(
-                                        android.widget.FrameLayout.LayoutParams.WRAP_CONTENT,
-                                        android.widget.FrameLayout.LayoutParams.WRAP_CONTENT);
-                        valParams.gravity = android.view.Gravity.CENTER;
-                        valTv.setLayoutParams(valParams);
-
-                        valTv.setTag(cellFgColor);
-
-                        if (damage.isLethal()) {
-                            valTv.setTextColor(ContextCompat.getColor(requireContext(), R.color.secondAccent));
-                        }
-
-                        cellLayout.addView(valTv);
-                        activeDialogDamageTextViews.put(sourceSeat, valTv);
-
-                        android.view.View divider = new android.view.View(requireContext());
-                        android.widget.FrameLayout.LayoutParams dividerParams =
-                                new android.widget.FrameLayout.LayoutParams(
-                                        (int) (1 * getResources().getDisplayMetrics().density),
-                                        android.widget.FrameLayout.LayoutParams.MATCH_PARENT);
-                        dividerParams.gravity = android.view.Gravity.CENTER;
-                        int dividerInset = (int) (8 * getResources().getDisplayMetrics().density);
-                        dividerParams.topMargin = dividerInset;
-                        dividerParams.bottomMargin = dividerInset;
-                        divider.setLayoutParams(dividerParams);
-                        divider.setBackgroundColor(adjustAlpha(cellFgColor, 0.2f));
-                        cellLayout.addView(divider);
-
-                        android.widget.LinearLayout tapZoneContainer =
-                                new android.widget.LinearLayout(requireContext());
-                        tapZoneContainer.setOrientation(android.widget.LinearLayout.HORIZONTAL);
-                        android.widget.FrameLayout.LayoutParams tapZoneParams =
-                                new android.widget.FrameLayout.LayoutParams(
-                                        android.widget.FrameLayout.LayoutParams.MATCH_PARENT,
-                                        android.widget.FrameLayout.LayoutParams.MATCH_PARENT);
-                        tapZoneContainer.setLayoutParams(tapZoneParams);
-
-                        android.view.View decrementZone =
-                                createCommanderDamageTapZone(
-                                        false,
-                                        cellFgColor,
-                                        getString(
-                                                R.string
-                                                        .mtg_commander_damage_decrease_desc,
-                                                sourceSeat + 1,
-                                                defenderSeatIndex + 1),
-                                        v ->
-                                                viewModel.decrementCommanderDamage(
-                                                        defenderSeatIndex, sourceSeat));
-                        android.view.View incrementZone =
-                                createCommanderDamageTapZone(
-                                        true,
-                                        cellFgColor,
-                                        getString(
-                                                R.string
-                                                        .mtg_commander_damage_increase_desc,
-                                                sourceSeat + 1,
-                                                defenderSeatIndex + 1),
-                                        v ->
-                                                viewModel.incrementCommanderDamage(
-                                                        defenderSeatIndex, sourceSeat));
-
-                        tapZoneContainer.addView(decrementZone);
-                        tapZoneContainer.addView(incrementZone);
-                        cellLayout.addView(tapZoneContainer);
-                    }
-
-                    rowLayout.addView(cellLayout);
+            for (int columnIndex = 0; columnIndex < cols; columnIndex++) {
+                int slotIndex = rowIndex * cols + columnIndex;
+                int sourceSeatIndex =
+                        getSourceSeatForGridSlot(slotIndex, defenderSeatIndex, totalPlayers);
+                if (sourceSeatIndex < damages.size()) {
+                    rowLayout.addView(
+                            createCommanderDialogCell(
+                                    damages.get(sourceSeatIndex), defenderSeatIndex));
                 } else {
-                    android.view.View spacer = new android.view.View(requireContext());
-                    android.widget.LinearLayout.LayoutParams spacerParams = new android.widget.LinearLayout.LayoutParams(
-                            0,
-                            (int) (64 * getResources().getDisplayMetrics().density),
-                            1f
-                    );
-                    int margin = (int) (4 * getResources().getDisplayMetrics().density);
-                    spacerParams.setMargins(margin, margin, margin, margin);
-                    spacer.setLayoutParams(spacerParams);
-                    spacer.setVisibility(android.view.View.INVISIBLE);
-                    rowLayout.addView(spacer);
+                    rowLayout.addView(createCommanderDialogSpacer());
                 }
             }
-            container.addView(rowLayout);
+
+            dialogContent.addView(rowLayout);
         }
 
-        gridSquare.addView(container);
-        dialogRoot.addView(gridSquare);
+        rotatedGrid.addView(dialogContent);
+        dialogRoot.addView(rotatedGrid);
 
-        builder.setView(dialogRoot);
+        MaterialAlertDialogBuilder dialogBuilder =
+                new MaterialAlertDialogBuilder(requireContext());
+        dialogBuilder.setView(dialogRoot);
 
-        android.app.Dialog dialog = builder.create();
-        dialog.setOnDismissListener(d -> {
-            activeDialogDefenderSeatIndex = null;
-            activeDialogDamageTextViews.clear();
-        });
-
+        Dialog dialog = dialogBuilder.create();
+        dialog.setOnDismissListener(
+                d -> {
+                    activeDialogDefenderSeatIndex = null;
+                    activeDialogDamageTextViews.clear();
+                });
         dialog.show();
 
         if (dialog.getWindow() != null) {
-            dialog.getWindow().setBackgroundDrawable(
-                    new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
+            dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         }
     }
 
-    private android.view.View createCommanderDamageTapZone(
+    private View createCommanderDialogCell(
+            CommanderDamageUiModel damage, int defenderSeatIndex) {
+        FrameLayout cellLayout = new FrameLayout(requireContext());
+        cellLayout.setClipToOutline(true);
+        cellLayout.setLayoutParams(createLargeGridLayoutParams());
+
+        if (damage.isSelf()) {
+            cellLayout.setVisibility(View.INVISIBLE);
+            return cellLayout;
+        }
+
+        int backgroundColor =
+                ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
+        int foregroundColor =
+                ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
+
+        GradientDrawable background = new GradientDrawable();
+        background.setCornerRadius(dpToPx(8));
+        background.setColor(backgroundColor);
+        cellLayout.setBackground(background);
+
+        TextView valueTextView = new TextView(requireContext());
+        valueTextView.setText(String.valueOf(damage.getAmount()));
+        valueTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
+        valueTextView.setTypeface(null, Typeface.BOLD);
+        valueTextView.setGravity(Gravity.CENTER);
+        valueTextView.setTextColor(foregroundColor);
+        valueTextView.setTag(foregroundColor);
+        if (damage.isLethal()) {
+            valueTextView.setTextColor(
+                    ContextCompat.getColor(requireContext(), R.color.secondAccent));
+        }
+
+        FrameLayout.LayoutParams valueParams =
+                new FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        Gravity.CENTER);
+        valueTextView.setLayoutParams(valueParams);
+        cellLayout.addView(valueTextView);
+        activeDialogDamageTextViews.put(damage.getSourceSeatIndex(), valueTextView);
+
+        View divider = new View(requireContext());
+        FrameLayout.LayoutParams dividerParams =
+                new FrameLayout.LayoutParams(dpToPx(1), FrameLayout.LayoutParams.MATCH_PARENT);
+        dividerParams.gravity = Gravity.CENTER;
+        dividerParams.topMargin = dpToPx(8);
+        dividerParams.bottomMargin = dpToPx(8);
+        divider.setLayoutParams(dividerParams);
+        divider.setBackgroundColor(adjustAlpha(foregroundColor, 0.2f));
+        cellLayout.addView(divider);
+
+        LinearLayout tapZoneContainer = new LinearLayout(requireContext());
+        tapZoneContainer.setOrientation(LinearLayout.HORIZONTAL);
+        tapZoneContainer.setLayoutParams(
+                new FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT));
+        tapZoneContainer.addView(
+                createCommanderDamageTapZone(
+                        false,
+                        foregroundColor,
+                        getString(
+                                R.string.mtg_commander_damage_decrease_desc,
+                                damage.getSourceSeatIndex() + 1,
+                                defenderSeatIndex + 1),
+                        v ->
+                                viewModel.decrementCommanderDamage(
+                                        defenderSeatIndex, damage.getSourceSeatIndex())));
+        tapZoneContainer.addView(
+                createCommanderDamageTapZone(
+                        true,
+                        foregroundColor,
+                        getString(
+                                R.string.mtg_commander_damage_increase_desc,
+                                damage.getSourceSeatIndex() + 1,
+                                defenderSeatIndex + 1),
+                        v ->
+                                viewModel.incrementCommanderDamage(
+                                        defenderSeatIndex, damage.getSourceSeatIndex())));
+        cellLayout.addView(tapZoneContainer);
+
+        return cellLayout;
+    }
+
+    private View createCommanderDialogSpacer() {
+        View spacer = new View(requireContext());
+        spacer.setLayoutParams(createLargeGridLayoutParams());
+        spacer.setVisibility(View.INVISIBLE);
+        return spacer;
+    }
+
+    private LinearLayout.LayoutParams createLargeGridLayoutParams() {
+        LinearLayout.LayoutParams params =
+                new LinearLayout.LayoutParams(0, dpToPx(64), 1f);
+        int margin = dpToPx(4);
+        params.setMargins(margin, margin, margin, margin);
+        return params;
+    }
+
+    private GradientDrawable createDialogBackground() {
+        TypedValue typedValue = new TypedValue();
+        requireContext()
+                .getTheme()
+                .resolveAttribute(android.R.attr.colorBackground, typedValue, true);
+
+        GradientDrawable background = new GradientDrawable();
+        background.setColor(typedValue.data);
+        background.setCornerRadius(dpToPx(10));
+        return background;
+    }
+
+    private View createCommanderDamageTapZone(
             boolean increment,
             int foregroundColor,
             String contentDescription,
-            android.view.View.OnClickListener onClickListener) {
-        android.view.View tapZone = new android.view.View(requireContext());
-        android.widget.LinearLayout.LayoutParams params =
-                new android.widget.LinearLayout.LayoutParams(
-                        0, android.widget.LinearLayout.LayoutParams.MATCH_PARENT, 1f);
-        tapZone.setLayoutParams(params);
+            View.OnClickListener onClickListener) {
+        View tapZone = new View(requireContext());
+        tapZone.setLayoutParams(
+                new LinearLayout.LayoutParams(
+                        0, LinearLayout.LayoutParams.MATCH_PARENT, 1f));
         tapZone.setClickable(true);
         tapZone.setFocusable(true);
         tapZone.setContentDescription(contentDescription);
         tapZone.setOnClickListener(onClickListener);
-
-        android.content.res.ColorStateList rippleColor =
-                android.content.res.ColorStateList.valueOf(adjustAlpha(foregroundColor, 0.18f));
-        android.graphics.drawable.RippleDrawable rippleDrawable =
-                new android.graphics.drawable.RippleDrawable(rippleColor, null, null);
-        tapZone.setBackground(rippleDrawable);
+        tapZone.setBackground(
+                new RippleDrawable(
+                        ColorStateList.valueOf(adjustAlpha(foregroundColor, 0.18f)),
+                        null,
+                        null));
         tapZone.setTag(increment ? "commander_increment_zone" : "commander_decrement_zone");
-
         return tapZone;
     }
 
-    private int adjustAlpha(int color, float alpha) {
-        int scaledAlpha = Math.round(android.graphics.Color.alpha(color) * alpha);
-        return androidx.core.graphics.ColorUtils.setAlphaComponent(color, scaledAlpha);
-    }
-
-    private int getSourceSeatForGridSlot(int idx, int defenderSeatIndex, int totalPlayers) {
-        if (totalPlayers == 4) {
-            if (defenderSeatIndex == 0 || defenderSeatIndex == 2) {
-                switch (idx) {
-                    case 0: return 1;
-                    case 1: return 3;
-                    case 2: return 0;
-                    case 3: return 2;
-                }
-            } else {
-                switch (idx) {
-                    case 0: return 2;
-                    case 1: return 0;
-                    case 2: return 3;
-                    case 3: return 1;
-                }
-            }
-        } else if (totalPlayers == 3) {
-            if (defenderSeatIndex == 0) {
-                switch (idx) {
-                    case 0: return 2;
-                    case 1: return 1;
-                    case 2: return 3; // spacer
-                    case 3: return 0;
-                }
-            } else if (defenderSeatIndex == 1) {
-                switch (idx) {
-                    case 0: return 0;
-                    case 1: return 2;
-                    case 2: return 3; // spacer
-                    case 3: return 1;
-                }
-            } else {
-                switch (idx) {
-                    case 0: return 1;
-                    case 1: return 0;
-                    case 2: return 2;
-                    case 3: return 3; // spacer
-                }
-            }
-        } else if (totalPlayers == 2) {
-            if (defenderSeatIndex == 0) {
-                return (idx == 0) ? 1 : 0;
-            } else {
-                return (idx == 0) ? 0 : 1;
-            }
-        } else if (totalPlayers == 6 || totalPlayers == 5) {
-            if (defenderSeatIndex == 4 && totalPlayers == 5) {
-                // Bottom player in 5-player game
-                switch (idx) {
-                    case 0: return 0;
-                    case 1: return 2;
-                    case 2: return 4;
-                    case 3: return 1;
-                    case 4: return 3;
-                    default: return 5; // spacer
-                }
-            }
-            if (defenderSeatIndex % 2 == 0) {
-                switch (idx) {
-                    case 0: return 1;
-                    case 1: return 3;
-                    case 2: return 5;
-                    case 3: return 0;
-                    case 4: return 2;
-                    default: return 4;
-                }
-            } else {
-                switch (idx) {
-                    case 0: return 4;
-                    case 1: return 2;
-                    case 2: return 0;
-                    case 3: return 5;
-                    case 4: return 3;
-                    default: return 1;
-                }
+    private LifePlayerUiModel findPlayerBySeat(
+            List<LifePlayerUiModel> players, int seatIndex) {
+        for (LifePlayerUiModel player : players) {
+            if (player.getSeatIndex() == seatIndex) {
+                return player;
             }
         }
-        return idx;
+        return null;
+    }
+
+    private int getSeatViewId(int seatIndex) {
+        return switch (seatIndex) {
+            case 0 -> R.id.player_1;
+            case 1 -> R.id.player_2;
+            case 2 -> R.id.player_3;
+            case 3 -> R.id.player_4;
+            case 4 -> R.id.player_5;
+            case 5 -> R.id.player_6;
+            default -> View.NO_ID;
+        };
+    }
+
+    private int getPreviewBackgroundColorRes(int seatIndex) {
+        return switch (seatIndex) {
+            case 0 -> R.color.lifeCounterPlayer1;
+            case 1 -> R.color.lifeCounterPlayer2;
+            case 2 -> R.color.lifeCounterPlayer3;
+            case 3 -> R.color.lifeCounterPlayer4;
+            default -> R.color.lifeCounterPlayer1;
+        };
+    }
+
+    private int getLifeCountMaxSizeSp(int playerCount) {
+        return switch (playerCount) {
+            case 1 -> 96;
+            case 2 -> 80;
+            case 3 -> 72;
+            case 4 -> 60;
+            case 5 -> 54;
+            case 6 -> 48;
+            default -> 60;
+        };
+    }
+
+    private int getCommanderGridRowCount(int totalPlayers) {
+        return totalPlayers > 2 ? 2 : 1;
+    }
+
+    private int getCommanderGridColumnCount(int totalPlayers) {
+        return totalPlayers > 4 ? 3 : 2;
+    }
+
+    private int getForegroundColor(int backgroundColor) {
+        return ColorUtils.calculateLuminance(backgroundColor) < 0.5 ? 0xFFFFFFFF : 0xFF000000;
+    }
+
+    private int adjustAlpha(int color, float alpha) {
+        int scaledAlpha = Math.round(Color.alpha(color) * alpha);
+        return ColorUtils.setAlphaComponent(color, scaledAlpha);
+    }
+
+    private int dpToPx(int dp) {
+        return (int) (dp * getResources().getDisplayMetrics().density);
+    }
+
+    private int getSourceSeatForGridSlot(int slotIndex, int defenderSeatIndex, int totalPlayers) {
+        int[] mapping =
+                switch (totalPlayers) {
+                    case 2 ->
+                            defenderSeatIndex == 0
+                                    ? new int[] {1, 0}
+                                    : new int[] {0, 1};
+                    case 3 ->
+                            switch (defenderSeatIndex) {
+                                case 0 -> new int[] {2, 1, 3, 0};
+                                case 1 -> new int[] {0, 2, 3, 1};
+                                default -> new int[] {1, 0, 2, 3};
+                            };
+                    case 4 ->
+                            switch (defenderSeatIndex) {
+                                case 0, 2 -> new int[] {1, 3, 0, 2};
+                                default -> new int[] {2, 0, 3, 1};
+                            };
+                    case 5 ->
+                            defenderSeatIndex == 4
+                                    ? new int[] {0, 2, 4, 1, 3, 5}
+                                    : defenderSeatIndex % 2 == 0
+                                            ? new int[] {1, 3, 5, 0, 2, 4}
+                                            : new int[] {4, 2, 0, 5, 3, 1};
+                    case 6 ->
+                            defenderSeatIndex % 2 == 0
+                                    ? new int[] {1, 3, 5, 0, 2, 4}
+                                    : new int[] {4, 2, 0, 5, 3, 1};
+                    default -> null;
+                };
+
+        if (mapping == null || slotIndex < 0 || slotIndex >= mapping.length) {
+            return slotIndex;
+        }
+        return mapping[slotIndex];
     }
 
     @Override
@@ -818,5 +701,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         binding = null;
         inputsInitialized = false;
         currentBoardPlayerCount = -1;
+        activeDialogDefenderSeatIndex = null;
+        activeDialogDamageTextViews.clear();
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -348,8 +348,9 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
                                                 for (int c = 0; c < cols; c++) {
                                                     int idx = r * cols + c;
-                                                    if (idx < damages.size()) {
-                                                        CommanderDamageUiModel damage = damages.get(idx);
+                                                    int targetSeat = getSourceSeatForGridSlot(idx, seatIndex, totalPlayers);
+                                                    if (targetSeat < damages.size()) {
+                                                        CommanderDamageUiModel damage = damages.get(targetSeat);
                                                         android.widget.TextView cellViewText = new android.widget.TextView(requireContext());
                                                         cellViewText.setGravity(android.view.Gravity.CENTER);
                                                         cellViewText.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 10);
@@ -487,119 +488,328 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
         com.google.android.material.dialog.MaterialAlertDialogBuilder builder =
                 new com.google.android.material.dialog.MaterialAlertDialogBuilder(requireContext());
+
+        int totalPlayers = uiState.getPlayerCount();
+        int rows = totalPlayers > 2 ? 2 : 1;
+        int cols = totalPlayers > 4 ? 3 : 2;
+
+        android.widget.FrameLayout dialogRoot = new android.widget.FrameLayout(requireContext());
+        android.widget.FrameLayout.LayoutParams rootParams = new android.widget.FrameLayout.LayoutParams(
+                android.widget.FrameLayout.LayoutParams.MATCH_PARENT,
+                android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
+        );
+        dialogRoot.setLayoutParams(rootParams);
+
+        int squareDimDp = (rows == 1) ? 176 : 228;
+        int squareDim = (int) (squareDimDp * getResources().getDisplayMetrics().density);
         
-        builder.setTitle(getString(R.string.mtg_commander_damage_dialog_title, defenderSeatIndex + 1));
+        android.widget.FrameLayout gridSquare = new android.widget.FrameLayout(requireContext());
+        android.widget.FrameLayout.LayoutParams squareParams = new android.widget.FrameLayout.LayoutParams(
+                squareDim, squareDim
+        );
+        squareParams.gravity = android.view.Gravity.CENTER;
+        gridSquare.setLayoutParams(squareParams);
+        gridSquare.setRotation(defender.getRotationDegrees());
 
         android.widget.LinearLayout container = new android.widget.LinearLayout(requireContext());
         container.setOrientation(android.widget.LinearLayout.VERTICAL);
-        int padding = (int) (16 * getResources().getDisplayMetrics().density);
-        container.setPadding(padding, padding, padding, padding);
+        container.setGravity(android.view.Gravity.CENTER);
+        
+        android.graphics.drawable.GradientDrawable containerBg = new android.graphics.drawable.GradientDrawable();
+        containerBg.setColor(0xE61A1A1A); // Translucent near-black background
+        containerBg.setCornerRadius(10 * getResources().getDisplayMetrics().density);
+        container.setBackground(containerBg);
+        
+        int pad = (int) (4 * getResources().getDisplayMetrics().density);
+        container.setPadding(pad, pad, pad, pad);
 
-        for (CommanderDamageUiModel dmg : defender.getCommanderDamages()) {
-            if (dmg.isSelf()) {
-                continue;
-            }
+        android.widget.FrameLayout.LayoutParams containerParams = new android.widget.FrameLayout.LayoutParams(
+                android.widget.FrameLayout.LayoutParams.MATCH_PARENT,
+                android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
+        );
+        containerParams.gravity = android.view.Gravity.CENTER;
+        container.setLayoutParams(containerParams);
 
-            int sourceSeat = dmg.getSourceSeatIndex();
-
-            android.widget.LinearLayout row = new android.widget.LinearLayout(requireContext());
-            row.setOrientation(android.widget.LinearLayout.HORIZONTAL);
-            row.setGravity(android.view.Gravity.CENTER_VERTICAL);
+        java.util.List<CommanderDamageUiModel> damages = defender.getCommanderDamages();
+        for (int r = 0; r < rows; r++) {
+            android.widget.LinearLayout rowLayout = new android.widget.LinearLayout(requireContext());
+            rowLayout.setOrientation(android.widget.LinearLayout.HORIZONTAL);
             android.widget.LinearLayout.LayoutParams rowParams = new android.widget.LinearLayout.LayoutParams(
                     android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
                     android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
             );
-            rowParams.setMargins(0, 0, 0, (int) (12 * getResources().getDisplayMetrics().density));
-            row.setLayoutParams(rowParams);
+            rowLayout.setLayoutParams(rowParams);
 
-            android.view.View colorIndicator = new android.view.View(requireContext());
-            int indicatorSize = (int) (16 * getResources().getDisplayMetrics().density);
-            android.widget.LinearLayout.LayoutParams indicatorParams = new android.widget.LinearLayout.LayoutParams(
-                    indicatorSize, indicatorSize
-            );
-            indicatorParams.setMargins(0, 0, (int) (12 * getResources().getDisplayMetrics().density), 0);
-            colorIndicator.setLayoutParams(indicatorParams);
+            for (int c = 0; c < cols; c++) {
+                int idx = r * cols + c;
+                int targetSeat = getSourceSeatForGridSlot(idx, defenderSeatIndex, totalPlayers);
+                if (targetSeat < damages.size()) {
+                    CommanderDamageUiModel damage = damages.get(targetSeat);
+                    
+                    android.widget.FrameLayout cellLayout =
+                            new android.widget.FrameLayout(requireContext());
+                    cellLayout.setClipToOutline(true);
+                    
+                    int cellBgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
+                    int cellFgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
 
-            android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
-            gd.setShape(android.graphics.drawable.GradientDrawable.OVAL);
-            gd.setColor(ContextCompat.getColor(requireContext(), dmg.getBackgroundColorRes()));
-            colorIndicator.setBackground(gd);
-            row.addView(colorIndicator);
+                    android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
+                    gd.setCornerRadius(8 * getResources().getDisplayMetrics().density);
+                    if (damage.isSelf()) {
+                        gd.setStroke((int) (1.5f * getResources().getDisplayMetrics().density), cellFgColor);
+                        gd.setColor(android.graphics.Color.TRANSPARENT);
+                    } else {
+                        gd.setColor(cellBgColor);
+                    }
+                    cellLayout.setBackground(gd);
 
-            android.widget.TextView labelTv = new android.widget.TextView(requireContext());
-            labelTv.setText(getString(R.string.mtg_commander_damage_player_label, sourceSeat + 1));
-            labelTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 16);
-            labelTv.setTypeface(null, android.graphics.Typeface.BOLD);
-            android.widget.LinearLayout.LayoutParams labelParams = new android.widget.LinearLayout.LayoutParams(
-                    0, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT, 1f
-            );
-            labelTv.setLayoutParams(labelParams);
-            row.addView(labelTv);
+                    android.widget.LinearLayout.LayoutParams cellParams = new android.widget.LinearLayout.LayoutParams(
+                            0,
+                            (int) (64 * getResources().getDisplayMetrics().density),
+                            1f
+                    );
+                    int margin = (int) (4 * getResources().getDisplayMetrics().density);
+                    cellParams.setMargins(margin, margin, margin, margin);
+                    cellLayout.setLayoutParams(cellParams);
 
-            com.google.android.material.button.MaterialButton btnMinus =
-                    new com.google.android.material.button.MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialButtonOutlinedStyle);
-            btnMinus.setIcon(ContextCompat.getDrawable(requireContext(), R.drawable.ic_remove_24));
-            btnMinus.setIconSize((int) (18 * getResources().getDisplayMetrics().density));
-            btnMinus.setIconPadding(0);
-            btnMinus.setInsetTop(0);
-            btnMinus.setInsetBottom(0);
-            android.widget.LinearLayout.LayoutParams btnMinusParams = new android.widget.LinearLayout.LayoutParams(
-                    (int) (40 * getResources().getDisplayMetrics().density),
-                    (int) (40 * getResources().getDisplayMetrics().density)
-            );
-            btnMinusParams.setMargins(0, 0, (int) (8 * getResources().getDisplayMetrics().density), 0);
-            btnMinus.setLayoutParams(btnMinusParams);
-            btnMinus.setOnClickListener(v -> viewModel.decrementCommanderDamage(defenderSeatIndex, sourceSeat));
-            row.addView(btnMinus);
+                    if (damage.isSelf()) {
+                        android.widget.TextView selfTv = new android.widget.TextView(requireContext());
+                        selfTv.setGravity(android.view.Gravity.CENTER);
+                        selfTv.setText(getString(R.string.mtg_commander_damage_self_label));
+                        selfTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 18);
+                        selfTv.setTypeface(null, android.graphics.Typeface.BOLD);
+                        selfTv.setTextColor(cellFgColor);
+                        selfTv.setEnabled(false);
+                        
+                        android.widget.LinearLayout.LayoutParams selfParams = new android.widget.LinearLayout.LayoutParams(
+                                android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
+                                android.widget.LinearLayout.LayoutParams.MATCH_PARENT
+                        );
+                        selfTv.setLayoutParams(selfParams);
+                        cellLayout.addView(selfTv);
+                    } else {
+                        int sourceSeat = damage.getSourceSeatIndex();
+                        android.widget.TextView valTv = new android.widget.TextView(requireContext());
+                        valTv.setText(String.valueOf(damage.getAmount()));
+                        valTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 20);
+                        valTv.setTypeface(null, android.graphics.Typeface.BOLD);
+                        valTv.setGravity(android.view.Gravity.CENTER);
+                        valTv.setTextColor(cellFgColor);
+                        
+                        android.widget.LinearLayout.LayoutParams valParams = new android.widget.LinearLayout.LayoutParams(
+                                0,
+                                android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
+                                1f
+                        );
+                        valTv.setLayoutParams(valParams);
 
-            android.widget.TextView valTv = new android.widget.TextView(requireContext());
-            valTv.setText(String.valueOf(dmg.getAmount()));
-            valTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 18);
-            valTv.setTypeface(null, android.graphics.Typeface.BOLD);
-            valTv.setGravity(android.view.Gravity.CENTER);
-            android.widget.LinearLayout.LayoutParams valParams = new android.widget.LinearLayout.LayoutParams(
-                    (int) (36 * getResources().getDisplayMetrics().density),
-                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-            );
-            valParams.setMargins(0, 0, (int) (8 * getResources().getDisplayMetrics().density), 0);
-            valTv.setLayoutParams(valParams);
+                        valTv.setTag(cellFgColor);
 
-            int defaultColor = valTv.getTextColors().getDefaultColor();
-            valTv.setTag(defaultColor);
+                        if (damage.isLethal()) {
+                            valTv.setTextColor(ContextCompat.getColor(requireContext(), R.color.secondAccent));
+                        }
 
-            if (dmg.isLethal()) {
-                valTv.setTextColor(ContextCompat.getColor(requireContext(), R.color.secondAccent));
+                        cellLayout.addView(valTv);
+                        activeDialogDamageTextViews.put(sourceSeat, valTv);
+
+                        android.view.View divider = new android.view.View(requireContext());
+                        android.widget.FrameLayout.LayoutParams dividerParams =
+                                new android.widget.FrameLayout.LayoutParams(
+                                        (int) (1 * getResources().getDisplayMetrics().density),
+                                        android.widget.FrameLayout.LayoutParams.MATCH_PARENT);
+                        dividerParams.gravity = android.view.Gravity.CENTER;
+                        int dividerInset = (int) (8 * getResources().getDisplayMetrics().density);
+                        dividerParams.topMargin = dividerInset;
+                        dividerParams.bottomMargin = dividerInset;
+                        divider.setLayoutParams(dividerParams);
+                        divider.setBackgroundColor(adjustAlpha(cellFgColor, 0.2f));
+                        cellLayout.addView(divider);
+
+                        android.widget.LinearLayout tapZoneContainer =
+                                new android.widget.LinearLayout(requireContext());
+                        tapZoneContainer.setOrientation(android.widget.LinearLayout.HORIZONTAL);
+                        android.widget.FrameLayout.LayoutParams tapZoneParams =
+                                new android.widget.FrameLayout.LayoutParams(
+                                        android.widget.FrameLayout.LayoutParams.MATCH_PARENT,
+                                        android.widget.FrameLayout.LayoutParams.MATCH_PARENT);
+                        tapZoneContainer.setLayoutParams(tapZoneParams);
+
+                        android.view.View decrementZone =
+                                createCommanderDamageTapZone(
+                                        false,
+                                        cellFgColor,
+                                        getString(
+                                                R.string
+                                                        .mtg_commander_damage_decrease_desc,
+                                                sourceSeat + 1,
+                                                defenderSeatIndex + 1),
+                                        v ->
+                                                viewModel.decrementCommanderDamage(
+                                                        defenderSeatIndex, sourceSeat));
+                        android.view.View incrementZone =
+                                createCommanderDamageTapZone(
+                                        true,
+                                        cellFgColor,
+                                        getString(
+                                                R.string
+                                                        .mtg_commander_damage_increase_desc,
+                                                sourceSeat + 1,
+                                                defenderSeatIndex + 1),
+                                        v ->
+                                                viewModel.incrementCommanderDamage(
+                                                        defenderSeatIndex, sourceSeat));
+
+                        tapZoneContainer.addView(decrementZone);
+                        tapZoneContainer.addView(incrementZone);
+                        cellLayout.addView(tapZoneContainer);
+                    }
+
+                    rowLayout.addView(cellLayout);
+                } else {
+                    android.view.View spacer = new android.view.View(requireContext());
+                    android.widget.LinearLayout.LayoutParams spacerParams = new android.widget.LinearLayout.LayoutParams(
+                            0,
+                            (int) (64 * getResources().getDisplayMetrics().density),
+                            1f
+                    );
+                    int margin = (int) (4 * getResources().getDisplayMetrics().density);
+                    spacerParams.setMargins(margin, margin, margin, margin);
+                    spacer.setLayoutParams(spacerParams);
+                    spacer.setVisibility(android.view.View.INVISIBLE);
+                    rowLayout.addView(spacer);
+                }
             }
-
-            row.addView(valTv);
-            activeDialogDamageTextViews.put(sourceSeat, valTv);
-
-            com.google.android.material.button.MaterialButton btnPlus =
-                    new com.google.android.material.button.MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialButtonOutlinedStyle);
-            btnPlus.setIcon(ContextCompat.getDrawable(requireContext(), R.drawable.ic_add_24));
-            btnPlus.setIconSize((int) (18 * getResources().getDisplayMetrics().density));
-            btnPlus.setIconPadding(0);
-            btnPlus.setInsetTop(0);
-            btnPlus.setInsetBottom(0);
-            android.widget.LinearLayout.LayoutParams btnPlusParams = new android.widget.LinearLayout.LayoutParams(
-                    (int) (40 * getResources().getDisplayMetrics().density),
-                    (int) (40 * getResources().getDisplayMetrics().density)
-            );
-            btnPlus.setLayoutParams(btnPlusParams);
-            btnPlus.setOnClickListener(v -> viewModel.incrementCommanderDamage(defenderSeatIndex, sourceSeat));
-            row.addView(btnPlus);
-
-            container.addView(row);
+            container.addView(rowLayout);
         }
 
-        builder.setView(container);
-        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss());
-        builder.setOnDismissListener(dialog -> {
+        gridSquare.addView(container);
+        dialogRoot.addView(gridSquare);
+
+        builder.setView(dialogRoot);
+
+        android.app.Dialog dialog = builder.create();
+        dialog.setOnDismissListener(d -> {
             activeDialogDefenderSeatIndex = null;
             activeDialogDamageTextViews.clear();
         });
 
-        builder.show();
+        dialog.show();
+
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().setBackgroundDrawable(
+                    new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
+        }
+    }
+
+    private android.view.View createCommanderDamageTapZone(
+            boolean increment,
+            int foregroundColor,
+            String contentDescription,
+            android.view.View.OnClickListener onClickListener) {
+        android.view.View tapZone = new android.view.View(requireContext());
+        android.widget.LinearLayout.LayoutParams params =
+                new android.widget.LinearLayout.LayoutParams(
+                        0, android.widget.LinearLayout.LayoutParams.MATCH_PARENT, 1f);
+        tapZone.setLayoutParams(params);
+        tapZone.setClickable(true);
+        tapZone.setFocusable(true);
+        tapZone.setContentDescription(contentDescription);
+        tapZone.setOnClickListener(onClickListener);
+
+        android.content.res.ColorStateList rippleColor =
+                android.content.res.ColorStateList.valueOf(adjustAlpha(foregroundColor, 0.18f));
+        android.graphics.drawable.RippleDrawable rippleDrawable =
+                new android.graphics.drawable.RippleDrawable(rippleColor, null, null);
+        tapZone.setBackground(rippleDrawable);
+        tapZone.setTag(increment ? "commander_increment_zone" : "commander_decrement_zone");
+
+        return tapZone;
+    }
+
+    private int adjustAlpha(int color, float alpha) {
+        int scaledAlpha = Math.round(android.graphics.Color.alpha(color) * alpha);
+        return androidx.core.graphics.ColorUtils.setAlphaComponent(color, scaledAlpha);
+    }
+
+    private int getSourceSeatForGridSlot(int idx, int defenderSeatIndex, int totalPlayers) {
+        if (totalPlayers == 4) {
+            if (defenderSeatIndex == 0 || defenderSeatIndex == 2) {
+                switch (idx) {
+                    case 0: return 1;
+                    case 1: return 3;
+                    case 2: return 0;
+                    case 3: return 2;
+                }
+            } else {
+                switch (idx) {
+                    case 0: return 2;
+                    case 1: return 0;
+                    case 2: return 3;
+                    case 3: return 1;
+                }
+            }
+        } else if (totalPlayers == 3) {
+            if (defenderSeatIndex == 0) {
+                switch (idx) {
+                    case 0: return 2;
+                    case 1: return 1;
+                    case 2: return 3; // spacer
+                    case 3: return 0;
+                }
+            } else if (defenderSeatIndex == 1) {
+                switch (idx) {
+                    case 0: return 0;
+                    case 1: return 2;
+                    case 2: return 3; // spacer
+                    case 3: return 1;
+                }
+            } else {
+                switch (idx) {
+                    case 0: return 1;
+                    case 1: return 0;
+                    case 2: return 2;
+                    case 3: return 3; // spacer
+                }
+            }
+        } else if (totalPlayers == 2) {
+            if (defenderSeatIndex == 0) {
+                return (idx == 0) ? 1 : 0;
+            } else {
+                return (idx == 0) ? 0 : 1;
+            }
+        } else if (totalPlayers == 6 || totalPlayers == 5) {
+            if (defenderSeatIndex == 4 && totalPlayers == 5) {
+                // Bottom player in 5-player game
+                switch (idx) {
+                    case 0: return 0;
+                    case 1: return 2;
+                    case 2: return 4;
+                    case 3: return 1;
+                    case 4: return 3;
+                    default: return 5; // spacer
+                }
+            }
+            if (defenderSeatIndex % 2 == 0) {
+                switch (idx) {
+                    case 0: return 1;
+                    case 1: return 3;
+                    case 2: return 5;
+                    case 3: return 0;
+                    case 4: return 2;
+                    default: return 4;
+                }
+            } else {
+                switch (idx) {
+                    case 0: return 4;
+                    case 1: return 2;
+                    case 2: return 0;
+                    case 3: return 5;
+                    case 4: return 3;
+                    default: return 1;
+                }
+            }
+        }
+        return idx;
     }
 
     @Override

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -141,6 +141,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                             String.valueOf(uiState.getPlayerCount()));
                                     setupBinding.lifeInput.setText(
                                             String.valueOf(uiState.getStartingLife()));
+                                    setupBinding.commanderDamageSwitch.setChecked(
+                                            uiState.isCommanderDamageEnabled());
                                     inputsInitialized = true;
                                 }
 
@@ -298,6 +300,97 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                                 getString(
                                                         R.string.mtg_btn_plus_desc, seatIndex + 1));
 
+                                        if (player.isCommanderDamageVisible()) {
+                                            cellBinding.commanderDamageGrid.setVisibility(View.VISIBLE);
+                                            cellBinding.commanderDamageGrid.removeAllViews();
+
+                                            int totalPlayers = uiState.getPlayerCount();
+                                            int rows = 1;
+                                            int cols = 2;
+                                            if (totalPlayers == 3 || totalPlayers == 4) {
+                                                rows = 2;
+                                                cols = 2;
+                                            } else if (totalPlayers >= 5) {
+                                                rows = 2;
+                                                cols = 3;
+                                            }
+                                            cellBinding.commanderDamageGrid.setRowCount(rows);
+                                            cellBinding.commanderDamageGrid.setColumnCount(cols);
+
+                                            final int seatIndex = player.getSeatIndex();
+                                            java.util.List<CommanderDamageUiModel> damages = player.getCommanderDamages();
+                                            for (int idx = 0; idx < damages.size(); idx++) {
+                                                CommanderDamageUiModel damage = damages.get(idx);
+                                                android.widget.TextView cellViewText = new android.widget.TextView(requireContext());
+                                                cellViewText.setGravity(android.view.Gravity.CENTER);
+                                                cellViewText.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 12);
+                                                cellViewText.setTypeface(null, android.graphics.Typeface.BOLD);
+
+                                                if (damage.isSelf()) {
+                                                    cellViewText.setText("me");
+                                                    cellViewText.setEnabled(false);
+                                                } else {
+                                                    cellViewText.setText(String.valueOf(damage.getAmount()));
+                                                }
+
+                                                int bgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
+                                                int fgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
+
+                                                android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
+                                                gd.setCornerRadius(4 * getResources().getDisplayMetrics().density);
+                                                if (damage.isSelf()) {
+                                                    gd.setStroke((int) (1 * getResources().getDisplayMetrics().density), fgColor);
+                                                    gd.setColor(android.graphics.Color.TRANSPARENT);
+                                                } else {
+                                                    gd.setColor(bgColor);
+                                                }
+                                                cellViewText.setBackground(gd);
+                                                cellViewText.setTextColor(fgColor);
+
+                                                int r = idx / cols;
+                                                int c = idx % cols;
+                                                android.widget.GridLayout.LayoutParams params = new android.widget.GridLayout.LayoutParams(
+                                                        android.widget.GridLayout.spec(r, 1f),
+                                                        android.widget.GridLayout.spec(c, 1f)
+                                                );
+                                                params.width = 0;
+                                                params.height = (int) (28 * getResources().getDisplayMetrics().density);
+                                                int margin = (int) (2 * getResources().getDisplayMetrics().density);
+                                                params.setMargins(margin, margin, margin, margin);
+                                                cellViewText.setLayoutParams(params);
+
+                                                if (!damage.isSelf()) {
+                                                    cellViewText.setOnClickListener(v -> viewModel.incrementCommanderDamage(seatIndex, damage.getSourceSeatIndex()));
+                                                    cellViewText.setOnLongClickListener(v -> {
+                                                        viewModel.decrementCommanderDamage(seatIndex, damage.getSourceSeatIndex());
+                                                        return true;
+                                                    });
+
+                                                    cellViewText.setContentDescription(getString(
+                                                            R.string.mtg_commander_damage_cell_desc,
+                                                            damage.getSourceSeatIndex() + 1,
+                                                            seatIndex + 1,
+                                                            damage.getAmount()
+                                                    ));
+
+                                                    androidx.core.view.ViewCompat.addAccessibilityAction(
+                                                            cellViewText,
+                                                            "Decrement commander damage",
+                                                            (v, args) -> {
+                                                                viewModel.decrementCommanderDamage(seatIndex, damage.getSourceSeatIndex());
+                                                                return true;
+                                                            }
+                                                    );
+                                                } else {
+                                                    cellViewText.setContentDescription(getString(R.string.mtg_commander_damage_self_desc));
+                                                }
+
+                                                cellBinding.commanderDamageGrid.addView(cellViewText);
+                                            }
+                                        } else {
+                                            cellBinding.commanderDamageGrid.setVisibility(View.GONE);
+                                        }
+
                                         float rotation = player.getRotationDegrees();
                                         cellBinding.playerCellContainer.setRotation(0f);
                                         cellBinding.innerPlayerLayout.setRotation(rotation);
@@ -310,7 +403,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                 v -> {
                     String playersStr = setupBinding.playersInput.getText().toString();
                     String lifeStr = setupBinding.lifeInput.getText().toString();
-                    viewModel.validateAndStartGame(playersStr, lifeStr);
+                    boolean commanderEnabled = setupBinding.commanderDamageSwitch.isChecked();
+                    viewModel.validateAndStartGame(playersStr, lifeStr, commanderEnabled);
                 });
 
         binding.setupOverlay.setOnClickListener(v -> viewModel.dismissSetup());

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -400,7 +400,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         FrameLayout rotatedGrid = new FrameLayout(requireContext());
         FrameLayout.LayoutParams rotatedGridParams =
                 new FrameLayout.LayoutParams(
-                        dpToPx(rows == 1 ? 176 : 228), dpToPx(rows == 1 ? 176 : 228));
+                        dpToPx(rows == 1 ? 224 : 288), dpToPx(rows == 1 ? 224 : 288));
         rotatedGridParams.gravity = Gravity.CENTER;
         rotatedGrid.setLayoutParams(rotatedGridParams);
         rotatedGrid.setRotation(defender.getRotationDegrees());
@@ -483,7 +483,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
         TextView valueTextView = new TextView(requireContext());
         valueTextView.setText(String.valueOf(damage.getAmount()));
-        valueTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
+        valueTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 28);
         valueTextView.setTypeface(null, Typeface.BOLD);
         valueTextView.setGravity(Gravity.CENTER);
         valueTextView.setTextColor(foregroundColor);
@@ -553,8 +553,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     }
 
     private LinearLayout.LayoutParams createLargeGridLayoutParams() {
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, dpToPx(64), 1f);
-        int margin = dpToPx(4);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, dpToPx(80), 1f);
+        int margin = dpToPx(8);
         params.setMargins(margin, margin, margin, margin);
         return params;
     }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -147,7 +147,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                             cellBinding.playerCellContainer.setBackgroundColor(
                                                     bgColor);
                                             cellBinding.tvLifeCount.setTextColor(fgColor);
-                                            cellBinding.tvLifeCount.setText("40");
+                                            cellBinding.tvLifeCount.setText(getString(R.string.default_mtg_life));
 
                                             cellBinding.btnMinus.setIconTint(
                                                     android.content.res.ColorStateList.valueOf(
@@ -333,15 +333,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                             cellBinding.commanderDamageGrid.removeAllViews();
 
                                             int totalPlayers = uiState.getPlayerCount();
-                                            int rows = 1;
-                                            int cols = 2;
-                                            if (totalPlayers == 3 || totalPlayers == 4) {
-                                                rows = 2;
-                                                cols = 2;
-                                            } else if (totalPlayers >= 5) {
-                                                rows = 2;
-                                                cols = 3;
-                                            }
+                                            int rows = totalPlayers > 2 ? 2 : 1;
+                                            int cols = totalPlayers > 4 ? 3 : 2;
 
                                             java.util.List<CommanderDamageUiModel> damages = player.getCommanderDamages();
                                             for (int r = 0; r < rows; r++) {
@@ -363,7 +356,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                                         cellViewText.setTypeface(null, android.graphics.Typeface.BOLD);
 
                                                         if (damage.isSelf()) {
-                                                            cellViewText.setText("me");
+                                                            cellViewText.setText(getString(R.string.mtg_commander_damage_self_label));
                                                             cellViewText.setEnabled(false);
                                                         } else {
                                                             cellViewText.setText(String.valueOf(damage.getAmount()));
@@ -422,7 +415,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                             }
 
                                             cellBinding.commanderDamageGrid.setOnClickListener(v -> showCommanderDamageDialog(seatIndex));
-                                            cellBinding.commanderDamageGrid.setContentDescription("Click to manage commander damage for player " + (seatIndex + 1));
+                                            cellBinding.commanderDamageGrid.setContentDescription(getString(R.string.mtg_commander_damage_manage_desc, seatIndex + 1));
                                         } else {
                                             cellBinding.commanderDamageGrid.setVisibility(View.GONE);
                                         }
@@ -437,8 +430,10 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
         setupBinding.startGameButton.setOnClickListener(
                 v -> {
-                    String playersStr = setupBinding.playersInput.getText().toString();
-                    String lifeStr = setupBinding.lifeInput.getText().toString();
+                    android.text.Editable playersText = setupBinding.playersInput.getText();
+                    android.text.Editable lifeText = setupBinding.lifeInput.getText();
+                    String playersStr = playersText != null ? playersText.toString() : "";
+                    String lifeStr = lifeText != null ? lifeText.toString() : "";
                     boolean commanderEnabled = setupBinding.commanderDamageSwitch.isChecked();
                     viewModel.validateAndStartGame(playersStr, lifeStr, commanderEnabled);
                 });

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -317,7 +317,6 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                             cellBinding.commanderDamageGrid.setRowCount(rows);
                                             cellBinding.commanderDamageGrid.setColumnCount(cols);
 
-                                            final int seatIndex = player.getSeatIndex();
                                             java.util.List<CommanderDamageUiModel> damages = player.getCommanderDamages();
                                             for (int idx = 0; idx < damages.size(); idx++) {
                                                 CommanderDamageUiModel damage = damages.get(idx);
@@ -333,19 +332,19 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                                     cellViewText.setText(String.valueOf(damage.getAmount()));
                                                 }
 
-                                                int bgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
-                                                int fgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
+                                                int cellBgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
+                                                int cellFgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
 
                                                 android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
                                                 gd.setCornerRadius(4 * getResources().getDisplayMetrics().density);
                                                 if (damage.isSelf()) {
-                                                    gd.setStroke((int) (1 * getResources().getDisplayMetrics().density), fgColor);
+                                                    gd.setStroke((int) (1 * getResources().getDisplayMetrics().density), cellFgColor);
                                                     gd.setColor(android.graphics.Color.TRANSPARENT);
                                                 } else {
-                                                    gd.setColor(bgColor);
+                                                    gd.setColor(cellBgColor);
                                                 }
                                                 cellViewText.setBackground(gd);
-                                                cellViewText.setTextColor(fgColor);
+                                                cellViewText.setTextColor(cellFgColor);
 
                                                 int r = idx / cols;
                                                 int c = idx % cols;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -406,6 +406,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         rotatedGrid.setRotation(defender.getRotationDegrees());
 
         LinearLayout dialogContent = new LinearLayout(requireContext());
+        dialogContent.setTag("commander_dialog_content");
         dialogContent.setOrientation(LinearLayout.VERTICAL);
         dialogContent.setGravity(Gravity.CENTER);
         dialogContent.setPadding(dpToPx(4), dpToPx(4), dpToPx(4), dpToPx(4));

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -33,6 +33,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     private MtgLifeViewModel viewModel;
     private boolean inputsInitialized = false;
     private int currentBoardPlayerCount = -1;
+    private Integer activeDialogDefenderSeatIndex = null;
+    private final java.util.Map<Integer, android.widget.TextView> activeDialogDamageTextViews = new java.util.HashMap<>();
 
     @Nullable @Override
     public View onCreateView(
@@ -58,6 +60,32 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         getViewLifecycleOwner(),
                         uiState -> {
                             requireActivity().invalidateOptionsMenu();
+
+                            if (activeDialogDefenderSeatIndex != null) {
+                                LifePlayerUiModel defender = null;
+                                for (LifePlayerUiModel p : uiState.getPlayers()) {
+                                    if (p.getSeatIndex() == activeDialogDefenderSeatIndex) {
+                                        defender = p;
+                                        break;
+                                    }
+                                }
+                                if (defender != null) {
+                                    for (CommanderDamageUiModel dmg : defender.getCommanderDamages()) {
+                                        android.widget.TextView tv = activeDialogDamageTextViews.get(dmg.getSourceSeatIndex());
+                                        if (tv != null) {
+                                            tv.setText(String.valueOf(dmg.getAmount()));
+                                            if (dmg.isLethal()) {
+                                                tv.setTextColor(ContextCompat.getColor(requireContext(), R.color.secondAccent));
+                                            } else {
+                                                Object tag = tv.getTag();
+                                                if (tag instanceof Integer) {
+                                                    tv.setTextColor((Integer) tag);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
 
                             if (uiState.isShowingSetup()) {
                                 binding.setupOverlay.setVisibility(View.VISIBLE);
@@ -314,78 +342,87 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                                                 rows = 2;
                                                 cols = 3;
                                             }
-                                            cellBinding.commanderDamageGrid.setRowCount(rows);
-                                            cellBinding.commanderDamageGrid.setColumnCount(cols);
 
                                             java.util.List<CommanderDamageUiModel> damages = player.getCommanderDamages();
-                                            for (int idx = 0; idx < damages.size(); idx++) {
-                                                CommanderDamageUiModel damage = damages.get(idx);
-                                                android.widget.TextView cellViewText = new android.widget.TextView(requireContext());
-                                                cellViewText.setGravity(android.view.Gravity.CENTER);
-                                                cellViewText.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 12);
-                                                cellViewText.setTypeface(null, android.graphics.Typeface.BOLD);
-
-                                                if (damage.isSelf()) {
-                                                    cellViewText.setText("me");
-                                                    cellViewText.setEnabled(false);
-                                                } else {
-                                                    cellViewText.setText(String.valueOf(damage.getAmount()));
-                                                }
-
-                                                int cellBgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
-                                                int cellFgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
-
-                                                android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
-                                                gd.setCornerRadius(4 * getResources().getDisplayMetrics().density);
-                                                if (damage.isSelf()) {
-                                                    gd.setStroke((int) (1 * getResources().getDisplayMetrics().density), cellFgColor);
-                                                    gd.setColor(android.graphics.Color.TRANSPARENT);
-                                                } else {
-                                                    gd.setColor(cellBgColor);
-                                                }
-                                                cellViewText.setBackground(gd);
-                                                cellViewText.setTextColor(cellFgColor);
-
-                                                int r = idx / cols;
-                                                int c = idx % cols;
-                                                android.widget.GridLayout.LayoutParams params = new android.widget.GridLayout.LayoutParams(
-                                                        android.widget.GridLayout.spec(r, 1f),
-                                                        android.widget.GridLayout.spec(c, 1f)
+                                            for (int r = 0; r < rows; r++) {
+                                                android.widget.LinearLayout rowLayout = new android.widget.LinearLayout(requireContext());
+                                                rowLayout.setOrientation(android.widget.LinearLayout.HORIZONTAL);
+                                                android.widget.LinearLayout.LayoutParams rowParams = new android.widget.LinearLayout.LayoutParams(
+                                                        android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
+                                                        android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
                                                 );
-                                                params.width = 0;
-                                                params.height = (int) (28 * getResources().getDisplayMetrics().density);
-                                                int margin = (int) (2 * getResources().getDisplayMetrics().density);
-                                                params.setMargins(margin, margin, margin, margin);
-                                                cellViewText.setLayoutParams(params);
+                                                rowLayout.setLayoutParams(rowParams);
 
-                                                if (!damage.isSelf()) {
-                                                    cellViewText.setOnClickListener(v -> viewModel.incrementCommanderDamage(seatIndex, damage.getSourceSeatIndex()));
-                                                    cellViewText.setOnLongClickListener(v -> {
-                                                        viewModel.decrementCommanderDamage(seatIndex, damage.getSourceSeatIndex());
-                                                        return true;
-                                                    });
+                                                for (int c = 0; c < cols; c++) {
+                                                    int idx = r * cols + c;
+                                                    if (idx < damages.size()) {
+                                                        CommanderDamageUiModel damage = damages.get(idx);
+                                                        android.widget.TextView cellViewText = new android.widget.TextView(requireContext());
+                                                        cellViewText.setGravity(android.view.Gravity.CENTER);
+                                                        cellViewText.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 10);
+                                                        cellViewText.setTypeface(null, android.graphics.Typeface.BOLD);
 
-                                                    cellViewText.setContentDescription(getString(
-                                                            R.string.mtg_commander_damage_cell_desc,
-                                                            damage.getSourceSeatIndex() + 1,
-                                                            seatIndex + 1,
-                                                            damage.getAmount()
-                                                    ));
+                                                        if (damage.isSelf()) {
+                                                            cellViewText.setText("me");
+                                                            cellViewText.setEnabled(false);
+                                                        } else {
+                                                            cellViewText.setText(String.valueOf(damage.getAmount()));
+                                                        }
 
-                                                    androidx.core.view.ViewCompat.addAccessibilityAction(
-                                                            cellViewText,
-                                                            "Decrement commander damage",
-                                                            (v, args) -> {
-                                                                viewModel.decrementCommanderDamage(seatIndex, damage.getSourceSeatIndex());
-                                                                return true;
-                                                            }
-                                                    );
-                                                } else {
-                                                    cellViewText.setContentDescription(getString(R.string.mtg_commander_damage_self_desc));
+                                                        int cellBgColor = ContextCompat.getColor(requireContext(), damage.getBackgroundColorRes());
+                                                        int cellFgColor = ContextCompat.getColor(requireContext(), damage.getForegroundColorRes());
+
+                                                        android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
+                                                        gd.setCornerRadius(4 * getResources().getDisplayMetrics().density);
+                                                        if (damage.isSelf()) {
+                                                            gd.setStroke((int) (1 * getResources().getDisplayMetrics().density), cellFgColor);
+                                                            gd.setColor(android.graphics.Color.TRANSPARENT);
+                                                        } else {
+                                                            gd.setColor(cellBgColor);
+                                                        }
+                                                        cellViewText.setBackground(gd);
+                                                        cellViewText.setTextColor(cellFgColor);
+
+                                                        android.widget.LinearLayout.LayoutParams params = new android.widget.LinearLayout.LayoutParams(
+                                                                0,
+                                                                (int) (16 * getResources().getDisplayMetrics().density),
+                                                                1f
+                                                        );
+                                                        int margin = (int) (2 * getResources().getDisplayMetrics().density);
+                                                        params.setMargins(margin, margin, margin, margin);
+                                                        cellViewText.setLayoutParams(params);
+
+                                                        if (!damage.isSelf()) {
+                                                            cellViewText.setContentDescription(getString(
+                                                                    R.string.mtg_commander_damage_cell_desc,
+                                                                    damage.getSourceSeatIndex() + 1,
+                                                                    seatIndex + 1,
+                                                                    damage.getAmount()
+                                                            ));
+                                                        } else {
+                                                            cellViewText.setContentDescription(getString(R.string.mtg_commander_damage_self_desc));
+                                                        }
+
+                                                        rowLayout.addView(cellViewText);
+                                                    } else {
+                                                        android.view.View spacer = new android.view.View(requireContext());
+                                                        android.widget.LinearLayout.LayoutParams params = new android.widget.LinearLayout.LayoutParams(
+                                                                0,
+                                                                (int) (16 * getResources().getDisplayMetrics().density),
+                                                                1f
+                                                        );
+                                                        int margin = (int) (2 * getResources().getDisplayMetrics().density);
+                                                        params.setMargins(margin, margin, margin, margin);
+                                                        spacer.setLayoutParams(params);
+                                                        spacer.setVisibility(android.view.View.INVISIBLE);
+                                                        rowLayout.addView(spacer);
+                                                    }
                                                 }
-
-                                                cellBinding.commanderDamageGrid.addView(cellViewText);
+                                                cellBinding.commanderDamageGrid.addView(rowLayout);
                                             }
+
+                                            cellBinding.commanderDamageGrid.setOnClickListener(v -> showCommanderDamageDialog(seatIndex));
+                                            cellBinding.commanderDamageGrid.setContentDescription("Click to manage commander damage for player " + (seatIndex + 1));
                                         } else {
                                             cellBinding.commanderDamageGrid.setVisibility(View.GONE);
                                         }
@@ -435,6 +472,139 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             return true;
         }
         return false;
+    }
+
+    private void showCommanderDamageDialog(int defenderSeatIndex) {
+        activeDialogDefenderSeatIndex = defenderSeatIndex;
+        activeDialogDamageTextViews.clear();
+
+        MtgLifeUiState uiState = viewModel.getUiState().getValue();
+        if (uiState == null) return;
+
+        LifePlayerUiModel defender = null;
+        for (LifePlayerUiModel p : uiState.getPlayers()) {
+            if (p.getSeatIndex() == defenderSeatIndex) {
+                defender = p;
+                break;
+            }
+        }
+        if (defender == null) return;
+
+        com.google.android.material.dialog.MaterialAlertDialogBuilder builder =
+                new com.google.android.material.dialog.MaterialAlertDialogBuilder(requireContext());
+        
+        builder.setTitle(getString(R.string.mtg_commander_damage_dialog_title, defenderSeatIndex + 1));
+
+        android.widget.LinearLayout container = new android.widget.LinearLayout(requireContext());
+        container.setOrientation(android.widget.LinearLayout.VERTICAL);
+        int padding = (int) (16 * getResources().getDisplayMetrics().density);
+        container.setPadding(padding, padding, padding, padding);
+
+        for (CommanderDamageUiModel dmg : defender.getCommanderDamages()) {
+            if (dmg.isSelf()) {
+                continue;
+            }
+
+            int sourceSeat = dmg.getSourceSeatIndex();
+
+            android.widget.LinearLayout row = new android.widget.LinearLayout(requireContext());
+            row.setOrientation(android.widget.LinearLayout.HORIZONTAL);
+            row.setGravity(android.view.Gravity.CENTER_VERTICAL);
+            android.widget.LinearLayout.LayoutParams rowParams = new android.widget.LinearLayout.LayoutParams(
+                    android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
+                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+            );
+            rowParams.setMargins(0, 0, 0, (int) (12 * getResources().getDisplayMetrics().density));
+            row.setLayoutParams(rowParams);
+
+            android.view.View colorIndicator = new android.view.View(requireContext());
+            int indicatorSize = (int) (16 * getResources().getDisplayMetrics().density);
+            android.widget.LinearLayout.LayoutParams indicatorParams = new android.widget.LinearLayout.LayoutParams(
+                    indicatorSize, indicatorSize
+            );
+            indicatorParams.setMargins(0, 0, (int) (12 * getResources().getDisplayMetrics().density), 0);
+            colorIndicator.setLayoutParams(indicatorParams);
+
+            android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
+            gd.setShape(android.graphics.drawable.GradientDrawable.OVAL);
+            gd.setColor(ContextCompat.getColor(requireContext(), dmg.getBackgroundColorRes()));
+            colorIndicator.setBackground(gd);
+            row.addView(colorIndicator);
+
+            android.widget.TextView labelTv = new android.widget.TextView(requireContext());
+            labelTv.setText(getString(R.string.mtg_commander_damage_player_label, sourceSeat + 1));
+            labelTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 16);
+            labelTv.setTypeface(null, android.graphics.Typeface.BOLD);
+            android.widget.LinearLayout.LayoutParams labelParams = new android.widget.LinearLayout.LayoutParams(
+                    0, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT, 1f
+            );
+            labelTv.setLayoutParams(labelParams);
+            row.addView(labelTv);
+
+            com.google.android.material.button.MaterialButton btnMinus =
+                    new com.google.android.material.button.MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialButtonOutlinedStyle);
+            btnMinus.setIcon(ContextCompat.getDrawable(requireContext(), R.drawable.ic_remove_24));
+            btnMinus.setIconSize((int) (18 * getResources().getDisplayMetrics().density));
+            btnMinus.setIconPadding(0);
+            btnMinus.setInsetTop(0);
+            btnMinus.setInsetBottom(0);
+            android.widget.LinearLayout.LayoutParams btnMinusParams = new android.widget.LinearLayout.LayoutParams(
+                    (int) (40 * getResources().getDisplayMetrics().density),
+                    (int) (40 * getResources().getDisplayMetrics().density)
+            );
+            btnMinusParams.setMargins(0, 0, (int) (8 * getResources().getDisplayMetrics().density), 0);
+            btnMinus.setLayoutParams(btnMinusParams);
+            btnMinus.setOnClickListener(v -> viewModel.decrementCommanderDamage(defenderSeatIndex, sourceSeat));
+            row.addView(btnMinus);
+
+            android.widget.TextView valTv = new android.widget.TextView(requireContext());
+            valTv.setText(String.valueOf(dmg.getAmount()));
+            valTv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 18);
+            valTv.setTypeface(null, android.graphics.Typeface.BOLD);
+            valTv.setGravity(android.view.Gravity.CENTER);
+            android.widget.LinearLayout.LayoutParams valParams = new android.widget.LinearLayout.LayoutParams(
+                    (int) (36 * getResources().getDisplayMetrics().density),
+                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+            );
+            valParams.setMargins(0, 0, (int) (8 * getResources().getDisplayMetrics().density), 0);
+            valTv.setLayoutParams(valParams);
+
+            int defaultColor = valTv.getTextColors().getDefaultColor();
+            valTv.setTag(defaultColor);
+
+            if (dmg.isLethal()) {
+                valTv.setTextColor(ContextCompat.getColor(requireContext(), R.color.secondAccent));
+            }
+
+            row.addView(valTv);
+            activeDialogDamageTextViews.put(sourceSeat, valTv);
+
+            com.google.android.material.button.MaterialButton btnPlus =
+                    new com.google.android.material.button.MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialButtonOutlinedStyle);
+            btnPlus.setIcon(ContextCompat.getDrawable(requireContext(), R.drawable.ic_add_24));
+            btnPlus.setIconSize((int) (18 * getResources().getDisplayMetrics().density));
+            btnPlus.setIconPadding(0);
+            btnPlus.setInsetTop(0);
+            btnPlus.setInsetBottom(0);
+            android.widget.LinearLayout.LayoutParams btnPlusParams = new android.widget.LinearLayout.LayoutParams(
+                    (int) (40 * getResources().getDisplayMetrics().density),
+                    (int) (40 * getResources().getDisplayMetrics().density)
+            );
+            btnPlus.setLayoutParams(btnPlusParams);
+            btnPlus.setOnClickListener(v -> viewModel.incrementCommanderDamage(defenderSeatIndex, sourceSeat));
+            row.addView(btnPlus);
+
+            container.addView(row);
+        }
+
+        builder.setView(container);
+        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss());
+        builder.setOnDismissListener(dialog -> {
+            activeDialogDefenderSeatIndex = null;
+            activeDialogDamageTextViews.clear();
+        });
+
+        builder.show();
     }
 
     @Override

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -670,7 +670,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                             };
                     case 5 ->
                             defenderSeatIndex == 4
-                                    ? new int[] {0, 2, 4, 1, 3, 5}
+                                    ? new int[] {0, 1, 4, 2, 3, 5}
                                     : defenderSeatIndex % 2 == 0
                                             ? new int[] {1, 3, 5, 0, 2, 4}
                                             : new int[] {4, 2, 0, 5, 3, 1};

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -596,11 +596,11 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         valTv.setGravity(android.view.Gravity.CENTER);
                         valTv.setTextColor(cellFgColor);
                         
-                        android.widget.LinearLayout.LayoutParams valParams = new android.widget.LinearLayout.LayoutParams(
-                                0,
-                                android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
-                                1f
-                        );
+                        android.widget.FrameLayout.LayoutParams valParams =
+                                new android.widget.FrameLayout.LayoutParams(
+                                        android.widget.FrameLayout.LayoutParams.WRAP_CONTENT,
+                                        android.widget.FrameLayout.LayoutParams.WRAP_CONTENT);
+                        valParams.gravity = android.view.Gravity.CENTER;
                         valTv.setLayoutParams(valParams);
 
                         valTv.setTag(cellFgColor);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -55,8 +55,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     private Integer activeDialogDefenderSeatIndex = null;
     private final Map<Integer, TextView> activeDialogDamageTextViews = new HashMap<>();
 
-    @Nullable
-    @Override
+    @Nullable @Override
     public View onCreateView(
             @NonNull LayoutInflater inflater,
             @Nullable ViewGroup container,
@@ -109,7 +108,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
         menuInflater.inflate(R.menu.life_actions, menu);
         MenuItem newGameItem = menu.findItem(R.id.action_new_game);
-        MtgLifeUiState currentUiState = viewModel != null ? viewModel.getUiState().getValue() : null;
+        MtgLifeUiState currentUiState =
+                viewModel != null ? viewModel.getUiState().getValue() : null;
         if (newGameItem != null && currentUiState != null) {
             newGameItem.setVisible(!currentUiState.isShowingSetup());
         }
@@ -129,7 +129,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             return;
         }
 
-        LifePlayerUiModel defender = findPlayerBySeat(uiState.getPlayers(), activeDialogDefenderSeatIndex);
+        LifePlayerUiModel defender =
+                findPlayerBySeat(uiState.getPlayers(), activeDialogDefenderSeatIndex);
         if (defender == null) {
             return;
         }
@@ -153,8 +154,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         }
     }
 
-    private void renderSetupState(
-            MtgLifeUiState uiState, LifeSetupContentBinding setupBinding) {
+    private void renderSetupState(MtgLifeUiState uiState, LifeSetupContentBinding setupBinding) {
         binding.setupOverlay.setVisibility(View.VISIBLE);
         binding.setupContent.getRoot().setVisibility(View.VISIBLE);
         binding.boardContainer.setVisibility(View.VISIBLE);
@@ -205,7 +205,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             case 4 -> LifeBoard4Binding.inflate(inflater, binding.boardContainer, true);
             case 5 -> LifeBoard5Binding.inflate(inflater, binding.boardContainer, true);
             case 6 -> LifeBoard6Binding.inflate(inflater, binding.boardContainer, true);
-            default -> throw new IllegalArgumentException("Unsupported player count: " + playerCount);
+            default ->
+                    throw new IllegalArgumentException("Unsupported player count: " + playerCount);
         }
     }
 
@@ -267,8 +268,10 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
         cellBinding.btnMinus.setIconTint(ColorStateList.valueOf(foregroundColor));
         cellBinding.btnPlus.setIconTint(ColorStateList.valueOf(foregroundColor));
-        cellBinding.btnMinus.setContentDescription(getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
-        cellBinding.btnPlus.setContentDescription(getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
+        cellBinding.btnMinus.setContentDescription(
+                getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
+        cellBinding.btnPlus.setContentDescription(
+                getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
         cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
         cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
 
@@ -304,10 +307,10 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
             for (int columnIndex = 0; columnIndex < cols; columnIndex++) {
                 int slotIndex = rowIndex * cols + columnIndex;
-                int sourceSeatIndex =
-                        getSourceSeatForGridSlot(slotIndex, seatIndex, totalPlayers);
+                int sourceSeatIndex = getSourceSeatForGridSlot(slotIndex, seatIndex, totalPlayers);
                 if (sourceSeatIndex < damages.size()) {
-                    rowLayout.addView(createCommanderSummaryCell(damages.get(sourceSeatIndex), seatIndex));
+                    rowLayout.addView(
+                            createCommanderSummaryCell(damages.get(sourceSeatIndex), seatIndex));
                 } else {
                     rowLayout.addView(createCommanderSummarySpacer());
                 }
@@ -316,13 +319,13 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             cellBinding.commanderDamageGrid.addView(rowLayout);
         }
 
-        cellBinding.commanderDamageGrid.setOnClickListener(v -> showCommanderDamageDialog(seatIndex));
+        cellBinding.commanderDamageGrid.setOnClickListener(
+                v -> showCommanderDamageDialog(seatIndex));
         cellBinding.commanderDamageGrid.setContentDescription(
                 getString(R.string.mtg_commander_damage_manage_desc, seatIndex + 1));
     }
 
-    private View createCommanderSummaryCell(
-            CommanderDamageUiModel damage, int defenderSeatIndex) {
+    private View createCommanderSummaryCell(CommanderDamageUiModel damage, int defenderSeatIndex) {
         TextView summaryCell = new TextView(requireContext());
         summaryCell.setGravity(Gravity.CENTER);
         summaryCell.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);
@@ -364,8 +367,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     }
 
     private LinearLayout.LayoutParams createSmallGridLayoutParams(int heightDp) {
-        LinearLayout.LayoutParams params =
-                new LinearLayout.LayoutParams(0, dpToPx(heightDp), 1f);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, dpToPx(heightDp), 1f);
         int margin = dpToPx(2);
         params.setMargins(margin, margin, margin, margin);
         return params;
@@ -442,8 +444,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         rotatedGrid.addView(dialogContent);
         dialogRoot.addView(rotatedGrid);
 
-        MaterialAlertDialogBuilder dialogBuilder =
-                new MaterialAlertDialogBuilder(requireContext());
+        MaterialAlertDialogBuilder dialogBuilder = new MaterialAlertDialogBuilder(requireContext());
         dialogBuilder.setView(dialogRoot);
 
         Dialog dialog = dialogBuilder.create();
@@ -459,8 +460,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         }
     }
 
-    private View createCommanderDialogCell(
-            CommanderDamageUiModel damage, int defenderSeatIndex) {
+    private View createCommanderDialogCell(CommanderDamageUiModel damage, int defenderSeatIndex) {
         FrameLayout cellLayout = new FrameLayout(requireContext());
         cellLayout.setClipToOutline(true);
         cellLayout.setLayoutParams(createLargeGridLayoutParams());
@@ -552,8 +552,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     }
 
     private LinearLayout.LayoutParams createLargeGridLayoutParams() {
-        LinearLayout.LayoutParams params =
-                new LinearLayout.LayoutParams(0, dpToPx(64), 1f);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, dpToPx(64), 1f);
         int margin = dpToPx(4);
         params.setMargins(margin, margin, margin, margin);
         return params;
@@ -578,23 +577,19 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             View.OnClickListener onClickListener) {
         View tapZone = new View(requireContext());
         tapZone.setLayoutParams(
-                new LinearLayout.LayoutParams(
-                        0, LinearLayout.LayoutParams.MATCH_PARENT, 1f));
+                new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f));
         tapZone.setClickable(true);
         tapZone.setFocusable(true);
         tapZone.setContentDescription(contentDescription);
         tapZone.setOnClickListener(onClickListener);
         tapZone.setBackground(
                 new RippleDrawable(
-                        ColorStateList.valueOf(adjustAlpha(foregroundColor, 0.18f)),
-                        null,
-                        null));
+                        ColorStateList.valueOf(adjustAlpha(foregroundColor, 0.18f)), null, null));
         tapZone.setTag(increment ? "commander_increment_zone" : "commander_decrement_zone");
         return tapZone;
     }
 
-    private LifePlayerUiModel findPlayerBySeat(
-            List<LifePlayerUiModel> players, int seatIndex) {
+    private LifePlayerUiModel findPlayerBySeat(List<LifePlayerUiModel> players, int seatIndex) {
         for (LifePlayerUiModel player : players) {
             if (player.getSeatIndex() == seatIndex) {
                 return player;
@@ -661,10 +656,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     private int getSourceSeatForGridSlot(int slotIndex, int defenderSeatIndex, int totalPlayers) {
         int[] mapping =
                 switch (totalPlayers) {
-                    case 2 ->
-                            defenderSeatIndex == 0
-                                    ? new int[] {1, 0}
-                                    : new int[] {0, 1};
+                    case 2 -> defenderSeatIndex == 0 ? new int[] {1, 0} : new int[] {0, 1};
                     case 3 ->
                             switch (defenderSeatIndex) {
                                 case 0 -> new int[] {2, 1, 3, 0};

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeUiState.java
@@ -9,6 +9,7 @@ public class MtgLifeUiState {
     private final List<LifePlayerUiModel> players;
     private final Integer playersErrorResId;
     private final Integer lifeErrorResId;
+    private final boolean commanderDamageEnabled;
 
     public MtgLifeUiState(
             boolean showingSetup,
@@ -16,13 +17,15 @@ public class MtgLifeUiState {
             int startingLife,
             List<LifePlayerUiModel> players,
             Integer playersErrorResId,
-            Integer lifeErrorResId) {
+            Integer lifeErrorResId,
+            boolean commanderDamageEnabled) {
         this.showingSetup = showingSetup;
         this.playerCount = playerCount;
         this.startingLife = startingLife;
         this.players = players;
         this.playersErrorResId = playersErrorResId;
         this.lifeErrorResId = lifeErrorResId;
+        this.commanderDamageEnabled = commanderDamageEnabled;
     }
 
     public boolean isShowingSetup() {
@@ -47,5 +50,9 @@ public class MtgLifeUiState {
 
     public Integer getLifeErrorResId() {
         return lifeErrorResId;
+    }
+
+    public boolean isCommanderDamageEnabled() {
+        return commanderDamageEnabled;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -15,6 +15,8 @@ public class MtgLifeViewModel extends ViewModel {
     private static final String KEY_CURRENT_LIVES = "currentLives";
     private static final String KEY_PLAYERS_ERROR_RES_ID = "playersErrorResId";
     private static final String KEY_LIFE_ERROR_RES_ID = "lifeErrorResId";
+    private static final String KEY_COMMANDER_DAMAGE_ENABLED = "commanderDamageEnabled";
+    private static final String KEY_COMMANDER_DAMAGE_MATRIX = "commanderDamageMatrix";
 
     private final SavedStateHandle savedStateHandle;
     private final MutableLiveData<MtgLifeUiState> uiState = new MutableLiveData<>();
@@ -29,6 +31,8 @@ public class MtgLifeViewModel extends ViewModel {
             savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
             savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
             savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
+            savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, true);
+            savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, new ArrayList<ArrayList<Integer>>());
         }
 
         updateUiState();
@@ -39,6 +43,11 @@ public class MtgLifeViewModel extends ViewModel {
     }
 
     public void validateAndStartGame(String playersStr, String lifeStr) {
+        Boolean lastEnabled = savedStateHandle.get(KEY_COMMANDER_DAMAGE_ENABLED);
+        validateAndStartGame(playersStr, lifeStr, lastEnabled == null || lastEnabled);
+    }
+
+    public void validateAndStartGame(String playersStr, String lifeStr, boolean commanderDamageEnabled) {
         boolean valid = true;
         Integer playersError = null;
         Integer lifeError = null;
@@ -79,6 +88,18 @@ public class MtgLifeViewModel extends ViewModel {
                 lives.add(life);
             }
             savedStateHandle.set(KEY_CURRENT_LIVES, lives);
+            savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, commanderDamageEnabled);
+
+            ArrayList<ArrayList<Integer>> matrix = new ArrayList<>();
+            for (int d = 0; d < players; d++) {
+                ArrayList<Integer> row = new ArrayList<>();
+                for (int s = 0; s < players; s++) {
+                    row.add(0);
+                }
+                matrix.add(row);
+            }
+            savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, matrix);
+
             savedStateHandle.set(KEY_SHOWING_SETUP, false);
         }
 
@@ -100,6 +121,41 @@ public class MtgLifeViewModel extends ViewModel {
             currentLives.set(seatIndex, currentLives.get(seatIndex) - 1);
             savedStateHandle.set(KEY_CURRENT_LIVES, currentLives);
             updateUiState();
+        }
+    }
+
+    public void incrementCommanderDamage(int defenderSeatIndex, int sourceSeatIndex) {
+        ArrayList<ArrayList<Integer>> matrix = savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
+        if (matrix != null && defenderSeatIndex >= 0 && defenderSeatIndex < matrix.size()) {
+            ArrayList<Integer> row = new ArrayList<>(matrix.get(defenderSeatIndex));
+            if (sourceSeatIndex >= 0 && sourceSeatIndex < row.size()) {
+                if (defenderSeatIndex != sourceSeatIndex) {
+                    row.set(sourceSeatIndex, row.get(sourceSeatIndex) + 1);
+                    ArrayList<ArrayList<Integer>> newMatrix = new ArrayList<>(matrix);
+                    newMatrix.set(defenderSeatIndex, row);
+                    savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, newMatrix);
+                    updateUiState();
+                }
+            }
+        }
+    }
+
+    public void decrementCommanderDamage(int defenderSeatIndex, int sourceSeatIndex) {
+        ArrayList<ArrayList<Integer>> matrix = savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
+        if (matrix != null && defenderSeatIndex >= 0 && defenderSeatIndex < matrix.size()) {
+            ArrayList<Integer> row = new ArrayList<>(matrix.get(defenderSeatIndex));
+            if (sourceSeatIndex >= 0 && sourceSeatIndex < row.size()) {
+                if (defenderSeatIndex != sourceSeatIndex) {
+                    int val = row.get(sourceSeatIndex);
+                    if (val > 0) {
+                        row.set(sourceSeatIndex, val - 1);
+                        ArrayList<ArrayList<Integer>> newMatrix = new ArrayList<>(matrix);
+                        newMatrix.set(defenderSeatIndex, row);
+                        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, newMatrix);
+                        updateUiState();
+                    }
+                }
+            }
         }
     }
 
@@ -179,6 +235,35 @@ public class MtgLifeViewModel extends ViewModel {
         }
     }
 
+    private List<CommanderDamageUiModel> buildCommanderDamages(int defenderIndex, ArrayList<ArrayList<Integer>> matrix, int totalPlayers) {
+        List<CommanderDamageUiModel> list = new ArrayList<>();
+        ArrayList<Integer> row = (matrix != null && defenderIndex < matrix.size()) ? matrix.get(defenderIndex) : null;
+        for (int sourceIndex = 0; sourceIndex < totalPlayers; sourceIndex++) {
+            int amount = 0;
+            if (row != null && sourceIndex < row.size()) {
+                amount = row.get(sourceIndex);
+            }
+            boolean self = (sourceIndex == defenderIndex);
+            boolean lethal = amount >= 21;
+
+            int bg;
+            int fg;
+            if (self) {
+                bg = android.R.color.transparent;
+                fg = R.color.m3_outline;
+            } else if (lethal) {
+                bg = R.color.secondAccent;
+                fg = android.R.color.white;
+            } else {
+                bg = getBackgroundColorResForSeat(sourceIndex);
+                fg = getForegroundColorResForSeat(sourceIndex);
+            }
+
+            list.add(new CommanderDamageUiModel(sourceIndex, amount, self, lethal, bg, fg));
+        }
+        return list;
+    }
+
     private void updateUiState() {
         boolean showingSetup = savedStateHandle.get(KEY_SHOWING_SETUP);
         int playerCount = savedStateHandle.get(KEY_PLAYER_COUNT);
@@ -187,6 +272,11 @@ public class MtgLifeViewModel extends ViewModel {
         Integer playersErrorResId = savedStateHandle.get(KEY_PLAYERS_ERROR_RES_ID);
         Integer lifeErrorResId = savedStateHandle.get(KEY_LIFE_ERROR_RES_ID);
 
+        Boolean enabled = savedStateHandle.get(KEY_COMMANDER_DAMAGE_ENABLED);
+        boolean isEnabled = (enabled != null) ? enabled : true;
+
+        ArrayList<ArrayList<Integer>> matrix = savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
+
         List<LifePlayerUiModel> playerModels = new ArrayList<>();
         if (!showingSetup && currentLives != null) {
             int size = currentLives.size();
@@ -194,7 +284,9 @@ public class MtgLifeViewModel extends ViewModel {
                 int rotation = getRotationForSeat(i, size);
                 int bg = getBackgroundColorResForSeat(i);
                 int fg = getForegroundColorResForSeat(i);
-                playerModels.add(new LifePlayerUiModel(i, currentLives.get(i), rotation, bg, fg));
+                boolean isVisible = isEnabled && (size > 1);
+                List<CommanderDamageUiModel> damages = buildCommanderDamages(i, matrix, size);
+                playerModels.add(new LifePlayerUiModel(i, currentLives.get(i), rotation, bg, fg, isVisible, damages));
             }
         }
 
@@ -205,6 +297,7 @@ public class MtgLifeViewModel extends ViewModel {
                         startingLife,
                         playerModels,
                         playersErrorResId,
-                        lifeErrorResId));
+                        lifeErrorResId,
+                        isEnabled));
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -67,7 +67,8 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(
                 KEY_CURRENT_LIVES, createInitialLives(parsedPlayerCount, parsedStartingLife));
         savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, commanderDamageEnabled);
-        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(parsedPlayerCount));
+        savedStateHandle.set(
+                KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(parsedPlayerCount));
         savedStateHandle.set(KEY_SHOWING_SETUP, false);
 
         updateUiState();
@@ -171,9 +172,7 @@ public class MtgLifeViewModel extends ViewModel {
 
     private void updateCommanderDamage(int defenderSeatIndex, int sourceSeatIndex, int delta) {
         ArrayList<ArrayList<Integer>> matrix = getCommanderDamageMatrix();
-        if (matrix == null
-                || !isValidSeatIndex(matrix, defenderSeatIndex)
-                || defenderSeatIndex == sourceSeatIndex) {
+        if (!isValidSeatIndex(matrix, defenderSeatIndex) || defenderSeatIndex == sourceSeatIndex) {
             return;
         }
 
@@ -243,11 +242,12 @@ public class MtgLifeViewModel extends ViewModel {
         return switch (totalPlayers) {
             case 1 -> 0;
             case 2 -> seatIndex == 0 ? 180 : 0;
-            case 3 -> switch (seatIndex) {
-                case 0 -> 180;
-                case 1 -> 90;
-                default -> 270;
-            };
+            case 3 ->
+                    switch (seatIndex) {
+                        case 0 -> 180;
+                        case 1 -> 90;
+                        default -> 270;
+                    };
             case 4 -> seatIndex % 2 == 0 ? 90 : 270;
             case 5 -> seatIndex == 4 ? 0 : (seatIndex % 2 == 0 ? 90 : 270);
             case 6 -> seatIndex % 2 == 0 ? 90 : 270;
@@ -283,7 +283,9 @@ public class MtgLifeViewModel extends ViewModel {
             int defenderSeatIndex, ArrayList<ArrayList<Integer>> matrix, int totalPlayers) {
         List<CommanderDamageUiModel> damages = new ArrayList<>();
         ArrayList<Integer> defenderRow =
-                matrix != null && defenderSeatIndex < matrix.size() ? matrix.get(defenderSeatIndex) : null;
+                matrix != null && defenderSeatIndex < matrix.size()
+                        ? matrix.get(defenderSeatIndex)
+                        : null;
 
         for (int sourceSeatIndex = 0; sourceSeatIndex < totalPlayers; sourceSeatIndex++) {
             int amount =

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -18,6 +18,12 @@ public class MtgLifeViewModel extends ViewModel {
     private static final String KEY_COMMANDER_DAMAGE_ENABLED = "commanderDamageEnabled";
     private static final String KEY_COMMANDER_DAMAGE_MATRIX = "commanderDamageMatrix";
 
+    private static final int DEFAULT_PLAYER_COUNT = 4;
+    private static final int DEFAULT_STARTING_LIFE = 40;
+    private static final int MIN_PLAYER_COUNT = 1;
+    private static final int MAX_PLAYER_COUNT = 6;
+    private static final int COMMANDER_LETHAL_DAMAGE = 21;
+
     private final SavedStateHandle savedStateHandle;
     private final MutableLiveData<MtgLifeUiState> uiState = new MutableLiveData<>();
 
@@ -25,14 +31,7 @@ public class MtgLifeViewModel extends ViewModel {
         this.savedStateHandle = savedStateHandle;
 
         if (!savedStateHandle.contains(KEY_SHOWING_SETUP)) {
-            savedStateHandle.set(KEY_SHOWING_SETUP, true);
-            savedStateHandle.set(KEY_PLAYER_COUNT, 4);
-            savedStateHandle.set(KEY_STARTING_LIFE, 40);
-            savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
-            savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
-            savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
-            savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, true);
-            savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, new ArrayList<ArrayList<Integer>>());
+            initializeDefaultState();
         }
 
         updateUiState();
@@ -43,120 +42,51 @@ public class MtgLifeViewModel extends ViewModel {
     }
 
     public void validateAndStartGame(String playersStr, String lifeStr) {
-        Boolean lastEnabled = savedStateHandle.get(KEY_COMMANDER_DAMAGE_ENABLED);
-        validateAndStartGame(playersStr, lifeStr, lastEnabled == null || lastEnabled);
+        validateAndStartGame(playersStr, lifeStr, getCommanderDamageEnabled());
     }
 
-    public void validateAndStartGame(String playersStr, String lifeStr, boolean commanderDamageEnabled) {
-        boolean valid = true;
-        Integer playersError = null;
-        Integer lifeError = null;
+    public void validateAndStartGame(
+            String playersStr, String lifeStr, boolean commanderDamageEnabled) {
+        Integer parsedPlayerCount = parsePlayerCount(playersStr);
+        Integer parsedStartingLife = parseStartingLife(lifeStr);
 
-        int players = 0;
-        try {
-            players = Integer.parseInt(playersStr);
-            if (players < 1 || players > 6) {
-                playersError = R.string.mtg_setup_players_error;
-                valid = false;
-            }
-        } catch (NumberFormatException e) {
-            playersError = R.string.mtg_setup_players_error;
-            valid = false;
+        savedStateHandle.set(
+                KEY_PLAYERS_ERROR_RES_ID,
+                parsedPlayerCount == null ? R.string.mtg_setup_players_error : null);
+        savedStateHandle.set(
+                KEY_LIFE_ERROR_RES_ID,
+                parsedStartingLife == null ? R.string.mtg_setup_life_error : null);
+
+        if (parsedPlayerCount == null || parsedStartingLife == null) {
+            updateUiState();
+            return;
         }
 
-        int life = 0;
-        try {
-            life = Integer.parseInt(lifeStr);
-            if (life <= 0) {
-                lifeError = R.string.mtg_setup_life_error;
-                valid = false;
-            }
-        } catch (NumberFormatException e) {
-            lifeError = R.string.mtg_setup_life_error;
-            valid = false;
-        }
-
-        savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, playersError);
-        savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, lifeError);
-
-        if (valid) {
-            savedStateHandle.set(KEY_PLAYER_COUNT, players);
-            savedStateHandle.set(KEY_STARTING_LIFE, life);
-
-            ArrayList<Integer> lives = new ArrayList<>();
-            for (int i = 0; i < players; i++) {
-                lives.add(life);
-            }
-            savedStateHandle.set(KEY_CURRENT_LIVES, lives);
-            savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, commanderDamageEnabled);
-
-            ArrayList<ArrayList<Integer>> matrix = new ArrayList<>();
-            for (int d = 0; d < players; d++) {
-                ArrayList<Integer> row = new ArrayList<>();
-                for (int s = 0; s < players; s++) {
-                    row.add(0);
-                }
-                matrix.add(row);
-            }
-            savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, matrix);
-
-            savedStateHandle.set(KEY_SHOWING_SETUP, false);
-        }
+        savedStateHandle.set(KEY_PLAYER_COUNT, parsedPlayerCount);
+        savedStateHandle.set(KEY_STARTING_LIFE, parsedStartingLife);
+        savedStateHandle.set(
+                KEY_CURRENT_LIVES, createInitialLives(parsedPlayerCount, parsedStartingLife));
+        savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, commanderDamageEnabled);
+        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(parsedPlayerCount));
+        savedStateHandle.set(KEY_SHOWING_SETUP, false);
 
         updateUiState();
     }
 
     public void incrementLife(int seatIndex) {
-        List<Integer> currentLives = new ArrayList<>(savedStateHandle.get(KEY_CURRENT_LIVES));
-        if (seatIndex >= 0 && seatIndex < currentLives.size()) {
-            currentLives.set(seatIndex, currentLives.get(seatIndex) + 1);
-            savedStateHandle.set(KEY_CURRENT_LIVES, currentLives);
-            updateUiState();
-        }
+        updateLifeTotal(seatIndex, 1);
     }
 
     public void decrementLife(int seatIndex) {
-        List<Integer> currentLives = new ArrayList<>(savedStateHandle.get(KEY_CURRENT_LIVES));
-        if (seatIndex >= 0 && seatIndex < currentLives.size()) {
-            currentLives.set(seatIndex, currentLives.get(seatIndex) - 1);
-            savedStateHandle.set(KEY_CURRENT_LIVES, currentLives);
-            updateUiState();
-        }
+        updateLifeTotal(seatIndex, -1);
     }
 
     public void incrementCommanderDamage(int defenderSeatIndex, int sourceSeatIndex) {
-        ArrayList<ArrayList<Integer>> matrix = savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
-        if (matrix != null && defenderSeatIndex >= 0 && defenderSeatIndex < matrix.size()) {
-            ArrayList<Integer> row = new ArrayList<>(matrix.get(defenderSeatIndex));
-            if (sourceSeatIndex >= 0 && sourceSeatIndex < row.size()) {
-                if (defenderSeatIndex != sourceSeatIndex) {
-                    row.set(sourceSeatIndex, row.get(sourceSeatIndex) + 1);
-                    ArrayList<ArrayList<Integer>> newMatrix = new ArrayList<>(matrix);
-                    newMatrix.set(defenderSeatIndex, row);
-                    savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, newMatrix);
-                    updateUiState();
-                }
-            }
-        }
+        updateCommanderDamage(defenderSeatIndex, sourceSeatIndex, 1);
     }
 
     public void decrementCommanderDamage(int defenderSeatIndex, int sourceSeatIndex) {
-        ArrayList<ArrayList<Integer>> matrix = savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
-        if (matrix != null && defenderSeatIndex >= 0 && defenderSeatIndex < matrix.size()) {
-            ArrayList<Integer> row = new ArrayList<>(matrix.get(defenderSeatIndex));
-            if (sourceSeatIndex >= 0 && sourceSeatIndex < row.size()) {
-                if (defenderSeatIndex != sourceSeatIndex) {
-                    int val = row.get(sourceSeatIndex);
-                    if (val > 0) {
-                        row.set(sourceSeatIndex, val - 1);
-                        ArrayList<ArrayList<Integer>> newMatrix = new ArrayList<>(matrix);
-                        newMatrix.set(defenderSeatIndex, row);
-                        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, newMatrix);
-                        updateUiState();
-                    }
-                }
-            }
-        }
+        updateCommanderDamage(defenderSeatIndex, sourceSeatIndex, -1);
     }
 
     public void resetToSetup() {
@@ -167,126 +97,252 @@ public class MtgLifeViewModel extends ViewModel {
     }
 
     public void dismissSetup() {
-        Boolean showing = savedStateHandle.get(KEY_SHOWING_SETUP);
-        List<Integer> currentLives = savedStateHandle.get(KEY_CURRENT_LIVES);
-        if (showing != null && showing && currentLives != null && !currentLives.isEmpty()) {
+        if (!isShowingSetup()) {
+            return;
+        }
+
+        List<Integer> currentLives = getCurrentLives();
+        if (currentLives != null && !currentLives.isEmpty()) {
             savedStateHandle.set(KEY_SHOWING_SETUP, false);
             updateUiState();
         }
     }
 
-    private int getRotationForSeat(int seatIndex, int totalPlayers) {
-        switch (totalPlayers) {
-            case 1:
-                return 0;
-            case 2:
-                return (seatIndex == 0) ? 180 : 0;
-            case 3:
-                if (seatIndex == 0) return 180;
-                if (seatIndex == 1) return 90;
-                return 270;
-            case 4:
-                return (seatIndex % 2 == 0) ? 90 : 270;
-            case 5:
-                if (seatIndex == 4) return 0;
-                return (seatIndex % 2 == 0) ? 90 : 270;
-            case 6:
-                return (seatIndex % 2 == 0) ? 90 : 270;
-            default:
-                return 0;
+    private void initializeDefaultState() {
+        savedStateHandle.set(KEY_SHOWING_SETUP, true);
+        savedStateHandle.set(KEY_PLAYER_COUNT, DEFAULT_PLAYER_COUNT);
+        savedStateHandle.set(KEY_STARTING_LIFE, DEFAULT_STARTING_LIFE);
+        savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
+        savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
+        savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
+        savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, true);
+        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, new ArrayList<ArrayList<Integer>>());
+    }
+
+    private Integer parsePlayerCount(String playersStr) {
+        try {
+            int players = Integer.parseInt(playersStr);
+            return players >= MIN_PLAYER_COUNT && players <= MAX_PLAYER_COUNT ? players : null;
+        } catch (NumberFormatException e) {
+            return null;
         }
+    }
+
+    private Integer parseStartingLife(String lifeStr) {
+        try {
+            int life = Integer.parseInt(lifeStr);
+            return life > 0 ? life : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private ArrayList<Integer> createInitialLives(int playerCount, int startingLife) {
+        ArrayList<Integer> lives = new ArrayList<>();
+        for (int i = 0; i < playerCount; i++) {
+            lives.add(startingLife);
+        }
+        return lives;
+    }
+
+    private ArrayList<ArrayList<Integer>> createCommanderDamageMatrix(int playerCount) {
+        ArrayList<ArrayList<Integer>> matrix = new ArrayList<>();
+        for (int defenderIndex = 0; defenderIndex < playerCount; defenderIndex++) {
+            ArrayList<Integer> row = new ArrayList<>();
+            for (int sourceIndex = 0; sourceIndex < playerCount; sourceIndex++) {
+                row.add(0);
+            }
+            matrix.add(row);
+        }
+        return matrix;
+    }
+
+    private void updateLifeTotal(int seatIndex, int delta) {
+        List<Integer> currentLives = getCurrentLives();
+        if (!isValidSeatIndex(currentLives, seatIndex)) {
+            return;
+        }
+
+        ArrayList<Integer> updatedLives = new ArrayList<>(currentLives);
+        updatedLives.set(seatIndex, updatedLives.get(seatIndex) + delta);
+        savedStateHandle.set(KEY_CURRENT_LIVES, updatedLives);
+        updateUiState();
+    }
+
+    private void updateCommanderDamage(int defenderSeatIndex, int sourceSeatIndex, int delta) {
+        ArrayList<ArrayList<Integer>> matrix = getCommanderDamageMatrix();
+        if (matrix == null
+                || !isValidSeatIndex(matrix, defenderSeatIndex)
+                || defenderSeatIndex == sourceSeatIndex) {
+            return;
+        }
+
+        ArrayList<Integer> defenderRow = new ArrayList<>(matrix.get(defenderSeatIndex));
+        if (!isValidSeatIndex(defenderRow, sourceSeatIndex)) {
+            return;
+        }
+
+        int currentAmount = defenderRow.get(sourceSeatIndex);
+        int updatedAmount = currentAmount + delta;
+        if (updatedAmount < 0) {
+            return;
+        }
+
+        defenderRow.set(sourceSeatIndex, updatedAmount);
+        ArrayList<ArrayList<Integer>> updatedMatrix = new ArrayList<>(matrix);
+        updatedMatrix.set(defenderSeatIndex, defenderRow);
+        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, updatedMatrix);
+
+        updateLifeTotalForCommanderDamage(defenderSeatIndex, -delta);
+        updateUiState();
+    }
+
+    private void updateLifeTotalForCommanderDamage(int defenderSeatIndex, int delta) {
+        List<Integer> currentLives = getCurrentLives();
+        if (!isValidSeatIndex(currentLives, defenderSeatIndex)) {
+            return;
+        }
+
+        ArrayList<Integer> updatedLives = new ArrayList<>(currentLives);
+        updatedLives.set(defenderSeatIndex, updatedLives.get(defenderSeatIndex) + delta);
+        savedStateHandle.set(KEY_CURRENT_LIVES, updatedLives);
+    }
+
+    private boolean isShowingSetup() {
+        return Boolean.TRUE.equals(savedStateHandle.get(KEY_SHOWING_SETUP));
+    }
+
+    private boolean getCommanderDamageEnabled() {
+        Boolean enabled = savedStateHandle.get(KEY_COMMANDER_DAMAGE_ENABLED);
+        return enabled == null || enabled;
+    }
+
+    private int getPlayerCount() {
+        Integer playerCount = savedStateHandle.get(KEY_PLAYER_COUNT);
+        return playerCount != null ? playerCount : DEFAULT_PLAYER_COUNT;
+    }
+
+    private int getStartingLife() {
+        Integer startingLife = savedStateHandle.get(KEY_STARTING_LIFE);
+        return startingLife != null ? startingLife : DEFAULT_STARTING_LIFE;
+    }
+
+    private List<Integer> getCurrentLives() {
+        return savedStateHandle.get(KEY_CURRENT_LIVES);
+    }
+
+    private ArrayList<ArrayList<Integer>> getCommanderDamageMatrix() {
+        return savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
+    }
+
+    private boolean isValidSeatIndex(List<?> list, int seatIndex) {
+        return list != null && seatIndex >= 0 && seatIndex < list.size();
+    }
+
+    private int getRotationForSeat(int seatIndex, int totalPlayers) {
+        return switch (totalPlayers) {
+            case 1 -> 0;
+            case 2 -> seatIndex == 0 ? 180 : 0;
+            case 3 -> switch (seatIndex) {
+                case 0 -> 180;
+                case 1 -> 90;
+                default -> 270;
+            };
+            case 4 -> seatIndex % 2 == 0 ? 90 : 270;
+            case 5 -> seatIndex == 4 ? 0 : (seatIndex % 2 == 0 ? 90 : 270);
+            case 6 -> seatIndex % 2 == 0 ? 90 : 270;
+            default -> 0;
+        };
     }
 
     private int getBackgroundColorResForSeat(int seatIndex) {
-        switch (seatIndex) {
-            case 0:
-                return R.color.lifeCounterPlayer1;
-            case 1:
-                return R.color.lifeCounterPlayer2;
-            case 2:
-                return R.color.lifeCounterPlayer3;
-            case 3:
-                return R.color.lifeCounterPlayer4;
-            case 4:
-                return R.color.lifeCounterPlayer5;
-            case 5:
-                return R.color.lifeCounterPlayer6;
-            default:
-                return R.color.lifeCounterPlayer1;
-        }
+        return switch (seatIndex) {
+            case 0 -> R.color.lifeCounterPlayer1;
+            case 1 -> R.color.lifeCounterPlayer2;
+            case 2 -> R.color.lifeCounterPlayer3;
+            case 3 -> R.color.lifeCounterPlayer4;
+            case 4 -> R.color.lifeCounterPlayer5;
+            case 5 -> R.color.lifeCounterPlayer6;
+            default -> R.color.lifeCounterPlayer1;
+        };
     }
 
     private int getForegroundColorResForSeat(int seatIndex) {
-        switch (seatIndex) {
-            case 0:
-                return R.color.lifeCounterOnPlayer1;
-            case 1:
-                return R.color.lifeCounterOnPlayer2;
-            case 2:
-                return R.color.lifeCounterOnPlayer3;
-            case 3:
-                return R.color.lifeCounterOnPlayer4;
-            case 4:
-                return R.color.lifeCounterOnPlayer5;
-            case 5:
-                return R.color.lifeCounterOnPlayer6;
-            default:
-                return R.color.lifeCounterOnPlayer1;
-        }
+        return switch (seatIndex) {
+            case 0 -> R.color.lifeCounterOnPlayer1;
+            case 1 -> R.color.lifeCounterOnPlayer2;
+            case 2 -> R.color.lifeCounterOnPlayer3;
+            case 3 -> R.color.lifeCounterOnPlayer4;
+            case 4 -> R.color.lifeCounterOnPlayer5;
+            case 5 -> R.color.lifeCounterOnPlayer6;
+            default -> R.color.lifeCounterOnPlayer1;
+        };
     }
 
-    private List<CommanderDamageUiModel> buildCommanderDamages(int defenderIndex, ArrayList<ArrayList<Integer>> matrix, int totalPlayers) {
-        List<CommanderDamageUiModel> list = new ArrayList<>();
-        ArrayList<Integer> row = (matrix != null && defenderIndex < matrix.size()) ? matrix.get(defenderIndex) : null;
-        for (int sourceIndex = 0; sourceIndex < totalPlayers; sourceIndex++) {
-            int amount = 0;
-            if (row != null && sourceIndex < row.size()) {
-                amount = row.get(sourceIndex);
-            }
-            boolean self = (sourceIndex == defenderIndex);
-            boolean lethal = amount >= 21;
+    private List<CommanderDamageUiModel> buildCommanderDamages(
+            int defenderSeatIndex, ArrayList<ArrayList<Integer>> matrix, int totalPlayers) {
+        List<CommanderDamageUiModel> damages = new ArrayList<>();
+        ArrayList<Integer> defenderRow =
+                matrix != null && defenderSeatIndex < matrix.size() ? matrix.get(defenderSeatIndex) : null;
 
-            int bg;
-            int fg;
-            if (self) {
-                bg = android.R.color.transparent;
-                fg = R.color.m3_outline;
-            } else if (lethal) {
-                bg = R.color.secondAccent;
-                fg = android.R.color.white;
-            } else {
-                bg = getBackgroundColorResForSeat(sourceIndex);
-                fg = getForegroundColorResForSeat(sourceIndex);
-            }
+        for (int sourceSeatIndex = 0; sourceSeatIndex < totalPlayers; sourceSeatIndex++) {
+            int amount =
+                    defenderRow != null && sourceSeatIndex < defenderRow.size()
+                            ? defenderRow.get(sourceSeatIndex)
+                            : 0;
+            boolean self = sourceSeatIndex == defenderSeatIndex;
+            boolean lethal = amount >= COMMANDER_LETHAL_DAMAGE;
 
-            list.add(new CommanderDamageUiModel(sourceIndex, amount, self, lethal, bg, fg));
+            int backgroundColorRes =
+                    self
+                            ? android.R.color.transparent
+                            : lethal
+                                    ? R.color.secondAccent
+                                    : getBackgroundColorResForSeat(sourceSeatIndex);
+            int foregroundColorRes =
+                    self
+                            ? R.color.m3_outline
+                            : lethal
+                                    ? android.R.color.white
+                                    : getForegroundColorResForSeat(sourceSeatIndex);
+
+            damages.add(
+                    new CommanderDamageUiModel(
+                            sourceSeatIndex,
+                            amount,
+                            self,
+                            lethal,
+                            backgroundColorRes,
+                            foregroundColorRes));
         }
-        return list;
+
+        return damages;
     }
 
     private void updateUiState() {
-        boolean showingSetup = savedStateHandle.get(KEY_SHOWING_SETUP);
-        int playerCount = savedStateHandle.get(KEY_PLAYER_COUNT);
-        int startingLife = savedStateHandle.get(KEY_STARTING_LIFE);
-        List<Integer> currentLives = savedStateHandle.get(KEY_CURRENT_LIVES);
+        boolean showingSetup = isShowingSetup();
+        int playerCount = getPlayerCount();
+        int startingLife = getStartingLife();
+        List<Integer> currentLives = getCurrentLives();
         Integer playersErrorResId = savedStateHandle.get(KEY_PLAYERS_ERROR_RES_ID);
         Integer lifeErrorResId = savedStateHandle.get(KEY_LIFE_ERROR_RES_ID);
+        boolean commanderDamageEnabled = getCommanderDamageEnabled();
+        ArrayList<ArrayList<Integer>> commanderDamageMatrix = getCommanderDamageMatrix();
 
-        Boolean enabled = savedStateHandle.get(KEY_COMMANDER_DAMAGE_ENABLED);
-        boolean isEnabled = (enabled != null) ? enabled : true;
-
-        ArrayList<ArrayList<Integer>> matrix = savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
-
-        List<LifePlayerUiModel> playerModels = new ArrayList<>();
+        List<LifePlayerUiModel> players = new ArrayList<>();
         if (!showingSetup && currentLives != null) {
-            int size = currentLives.size();
-            for (int i = 0; i < size; i++) {
-                int rotation = getRotationForSeat(i, size);
-                int bg = getBackgroundColorResForSeat(i);
-                int fg = getForegroundColorResForSeat(i);
-                boolean isVisible = isEnabled && (size > 1);
-                List<CommanderDamageUiModel> damages = buildCommanderDamages(i, matrix, size);
-                playerModels.add(new LifePlayerUiModel(i, currentLives.get(i), rotation, bg, fg, isVisible, damages));
+            int totalPlayers = currentLives.size();
+            for (int seatIndex = 0; seatIndex < totalPlayers; seatIndex++) {
+                players.add(
+                        new LifePlayerUiModel(
+                                seatIndex,
+                                currentLives.get(seatIndex),
+                                getRotationForSeat(seatIndex, totalPlayers),
+                                getBackgroundColorResForSeat(seatIndex),
+                                getForegroundColorResForSeat(seatIndex),
+                                commanderDamageEnabled && totalPlayers > 1,
+                                buildCommanderDamages(
+                                        seatIndex, commanderDamageMatrix, totalPlayers)));
             }
         }
 
@@ -295,9 +351,9 @@ public class MtgLifeViewModel extends ViewModel {
                         showingSetup,
                         playerCount,
                         startingLife,
-                        playerModels,
+                        players,
                         playersErrorResId,
                         lifeErrorResId,
-                        isEnabled));
+                        commanderDamageEnabled));
     }
 }

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -21,7 +21,7 @@
             style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            android:contentDescription="Decrease life"
+            android:contentDescription="@string/mtg_btn_minus_default_desc"
             android:insetLeft="0dp"
             android:insetTop="0dp"
             android:insetRight="0dp"
@@ -41,7 +41,7 @@
             android:gravity="center"
             android:includeFontPadding="false"
             android:maxLines="1"
-            android:text="40"
+            android:text="@string/default_mtg_life"
             android:textSize="96sp"
             android:textStyle="bold"
             app:autoSizeMinTextSize="20sp"
@@ -59,7 +59,7 @@
             style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            android:contentDescription="Increase life"
+            android:contentDescription="@string/mtg_btn_plus_default_desc"
             android:insetLeft="0dp"
             android:insetTop="0dp"
             android:insetRight="0dp"
@@ -72,10 +72,11 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <GridLayout
+        <LinearLayout
             android:id="@+id/commander_damage_grid"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
             android:layout_marginTop="4dp"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -48,7 +48,7 @@
             app:autoSizeMaxTextSize="108sp"
             app:autoSizeStepGranularity="2sp"
             app:autoSizeTextType="uniform"
-            app:layout_constraintBottom_toTopOf="@id/commander_damage_grid"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
             app:layout_constraintHeight_percent="0.6"
             app:layout_constraintStart_toEndOf="@id/btn_minus"
@@ -79,6 +79,8 @@
             android:orientation="vertical"
             android:layout_marginTop="4dp"
             android:visibility="gone"
+            app:layout_constraintWidth_percent="0.6"
+            app:layout_constraintWidth_max="140dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -48,7 +48,7 @@
             app:autoSizeMaxTextSize="108sp"
             app:autoSizeStepGranularity="2sp"
             app:autoSizeTextType="uniform"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/commander_damage_grid"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
             app:layout_constraintHeight_percent="0.6"
             app:layout_constraintStart_toEndOf="@id/btn_minus"
@@ -71,6 +71,16 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <GridLayout
+            android:id="@+id/commander_damage_grid"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/life_setup_content.xml
+++ b/app/src/main/res/layout/life_setup_content.xml
@@ -115,6 +115,27 @@
 
             </TableRow>
 
+            <TableRow
+                android:gravity="center_vertical"
+                android:layout_marginTop="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/mtg_setup_commander_damage"
+                    android:textAppearance="?attr/textAppearanceBodyLarge"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textStyle="bold"
+                    android:layout_marginEnd="24dp" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/commander_damage_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:checked="true" />
+
+            </TableRow>
+
         </TableLayout>
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -69,4 +69,14 @@
     <string name="mtg_player_label">Jugador %1$d</string>
     <string name="mtg_btn_minus_desc">Disminuir vida para el jugador %1$d</string>
     <string name="mtg_btn_plus_desc">Aumentar vida para el jugador %1$d</string>
+    <string name="mtg_setup_commander_damage">Daño de Comandante</string>
+    <string name="mtg_commander_damage_cell_desc">Daño de comandante del jugador %1$d al jugador %2$d: %3$d</string>
+    <string name="mtg_commander_damage_self_desc">Tu propia ranura de daño de comandante</string>
+    <string name="mtg_commander_damage_dialog_title">Daño de Comandante al Jugador %1$d</string>
+    <string name="mtg_commander_damage_player_label">Del Jugador %1$d</string>
+    <string name="mtg_btn_minus_default_desc">Disminuir vida</string>
+    <string name="mtg_btn_plus_default_desc">Aumentar vida</string>
+    <string name="default_mtg_life">40</string>
+    <string name="mtg_commander_damage_self_label">yo</string>
+    <string name="mtg_commander_damage_manage_desc">Haz clic para gestionar el daño de comandante del jugador %1$d</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,6 +74,8 @@
     <string name="mtg_commander_damage_self_desc">Tu propia ranura de daño de comandante</string>
     <string name="mtg_commander_damage_dialog_title">Daño de Comandante al Jugador %1$d</string>
     <string name="mtg_commander_damage_player_label">Del Jugador %1$d</string>
+    <string name="mtg_commander_damage_decrease_desc">Disminuir daño de comandante del jugador %1$d al jugador %2$d</string>
+    <string name="mtg_commander_damage_increase_desc">Aumentar daño de comandante del jugador %1$d al jugador %2$d</string>
     <string name="mtg_btn_minus_default_desc">Disminuir vida</string>
     <string name="mtg_btn_plus_default_desc">Aumentar vida</string>
     <string name="default_mtg_life">40</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,5 +85,8 @@
     <string name="mtg_btn_plus_default_desc">Increase life</string>
     <string name="default_mtg_life">40</string>
     <string name="mtg_commander_damage_self_label">me</string>
+    <string name="mtg_commander_damage_manage_desc">Click to manage commander damage for player %1$d</string>
+    <string name="mtg_btn_minus_commander_damage_desc">Decrease commander damage from player %1$d</string>
+    <string name="mtg_btn_plus_commander_damage_desc">Increase commander damage from player %1$d</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,8 @@
     <string name="mtg_commander_damage_self_desc">Your own commander damage slot</string>
     <string name="mtg_commander_damage_dialog_title">Commander Damage to Player %1$d</string>
     <string name="mtg_commander_damage_player_label">From Player %1$d</string>
+    <string name="mtg_commander_damage_decrease_desc">Decrease commander damage from player %1$d to player %2$d</string>
+    <string name="mtg_commander_damage_increase_desc">Increase commander damage from player %1$d to player %2$d</string>
     <string name="mtg_btn_minus_default_desc">Decrease life</string>
     <string name="mtg_btn_plus_default_desc">Increase life</string>
     <string name="default_mtg_life">40</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,5 +76,8 @@
     <string name="mtg_player_label">Player %1$d</string>
     <string name="mtg_btn_minus_desc">Decrease life for player %1$d</string>
     <string name="mtg_btn_plus_desc">Increase life for player %1$d</string>
+    <string name="mtg_setup_commander_damage">Commander Damage</string>
+    <string name="mtg_commander_damage_cell_desc">Commander damage from player %1$d to player %2$d: %3$d</string>
+    <string name="mtg_commander_damage_self_desc">Your own commander damage slot</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,5 +79,11 @@
     <string name="mtg_setup_commander_damage">Commander Damage</string>
     <string name="mtg_commander_damage_cell_desc">Commander damage from player %1$d to player %2$d: %3$d</string>
     <string name="mtg_commander_damage_self_desc">Your own commander damage slot</string>
+    <string name="mtg_commander_damage_dialog_title">Commander Damage to Player %1$d</string>
+    <string name="mtg_commander_damage_player_label">From Player %1$d</string>
+    <string name="mtg_btn_minus_default_desc">Decrease life</string>
+    <string name="mtg_btn_plus_default_desc">Increase life</string>
+    <string name="default_mtg_life">40</string>
+    <string name="mtg_commander_damage_self_label">me</string>
 
 </resources>

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -2,7 +2,10 @@ package com.nicue.onetwo.ui.life;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import android.app.Dialog;
+import android.os.Looper;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -14,7 +17,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowDialog;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
@@ -226,5 +231,86 @@ public class MtgLifeFragmentTest {
                     View setupOverlay = view.findViewById(R.id.setup_overlay);
                     assertEquals(View.GONE, setupOverlay.getVisibility());
                 });
+    }
+
+    @Test
+    public void testCommanderDamageDialogHalfTapZonesUpdateSummary() {
+        FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+
+        scenario.onFragment(
+                fragment -> {
+                    View view = fragment.getView();
+                    Button startButton = view.findViewById(R.id.start_game_button);
+                    startButton.performClick();
+                });
+
+        scenario.onFragment(
+                fragment -> {
+                    View player1 = fragment.requireView().findViewById(R.id.player_1);
+                    View commanderGrid = player1.findViewById(R.id.commander_damage_grid);
+                    assertNotNull(commanderGrid);
+                    try {
+                        java.lang.reflect.Method showDialogMethod =
+                                MtgLifeFragment.class.getDeclaredMethod(
+                                        "showCommanderDamageDialog", int.class);
+                        showDialogMethod.setAccessible(true);
+                        showDialogMethod.invoke(fragment, 0);
+                    } catch (ReflectiveOperationException e) {
+                        throw new AssertionError(e);
+                    }
+                    Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+                    Dialog dialog = ShadowDialog.getLatestDialog();
+                    assertNotNull(dialog);
+                    assertTrue(dialog.isShowing());
+
+                    View decorView = dialog.getWindow().getDecorView();
+                    View incrementZone =
+                            findViewWithContentDescription(
+                                    decorView,
+                                    fragment.getString(
+                                            R.string.mtg_commander_damage_increase_desc, 2, 1));
+                    View decrementZone =
+                            findViewWithContentDescription(
+                                    decorView,
+                                    fragment.getString(
+                                            R.string.mtg_commander_damage_decrease_desc, 2, 1));
+
+                    assertNotNull(incrementZone);
+                    assertNotNull(decrementZone);
+
+                    incrementZone.performClick();
+                    incrementZone.performClick();
+                    decrementZone.performClick();
+
+                    View updatedSummary =
+                            findViewWithContentDescription(
+                                    commanderGrid,
+                                    fragment.getString(
+                                            R.string.mtg_commander_damage_cell_desc, 2, 1, 1));
+                    assertNotNull(updatedSummary);
+                });
+    }
+
+    private static View findViewWithContentDescription(View root, CharSequence contentDescription) {
+        if (root == null) {
+            return null;
+        }
+        CharSequence rootDescription = root.getContentDescription();
+        if (rootDescription != null && rootDescription.toString().contentEquals(contentDescription)) {
+            return root;
+        }
+        if (root instanceof android.view.ViewGroup rootGroup) {
+            for (int i = 0; i < rootGroup.getChildCount(); i++) {
+                View match =
+                        findViewWithContentDescription(
+                                rootGroup.getChildAt(i), contentDescription);
+                if (match != null) {
+                    return match;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -29,268 +29,278 @@ public class MtgLifeFragmentTest {
 
     @Test
     public void testSetupStateVisibleOnFirstLaunchAndPrefilled() {
-        FragmentScenario<MtgLifeFragment> scenario =
-                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    assertNotNull(view);
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
 
-                    View setupContent = view.findViewById(R.id.setup_content);
-                    assertNotNull(setupContent);
-                    assertEquals(View.VISIBLE, setupContent.getVisibility());
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertNotNull(setupContent);
+                        assertEquals(View.VISIBLE, setupContent.getVisibility());
 
-                    View boardContainer = view.findViewById(R.id.board_container);
-                    assertNotNull(boardContainer);
-                    assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                        View boardContainer = view.findViewById(R.id.board_container);
+                        assertNotNull(boardContainer);
+                        assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-                    EditText playersInput = view.findViewById(R.id.players_input);
-                    EditText lifeInput = view.findViewById(R.id.life_input);
+                        EditText playersInput = view.findViewById(R.id.players_input);
+                        EditText lifeInput = view.findViewById(R.id.life_input);
 
-                    assertNotNull(playersInput);
-                    assertNotNull(lifeInput);
+                        assertNotNull(playersInput);
+                        assertNotNull(lifeInput);
 
-                    assertEquals("4", playersInput.getText().toString());
-                    assertEquals("40", lifeInput.getText().toString());
-                });
+                        assertEquals("4", playersInput.getText().toString());
+                        assertEquals("40", lifeInput.getText().toString());
+                    });
+        }
     }
 
     @Test
     public void testStartGameSwapsToBoardAndTappingPlusMinusUpdatesTotals() {
-        FragmentScenario<MtgLifeFragment> scenario =
-                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-        // 1. Press Start Game with defaults (4 players, 40 life)
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    Button startButton = view.findViewById(R.id.start_game_button);
-                    assertNotNull(startButton);
-                    startButton.performClick();
-                });
+            // 1. Press Start Game with defaults (4 players, 40 life)
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        assertNotNull(startButton);
+                        startButton.performClick();
+                    });
 
-        // 2. Verify we transitioned to playing board state (4 players board)
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View setupContent = view.findViewById(R.id.setup_content);
-                    assertEquals(View.GONE, setupContent.getVisibility());
+            // 2. Verify we transitioned to playing board state (4 players board)
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertEquals(View.GONE, setupContent.getVisibility());
 
-                    View boardContainer = view.findViewById(R.id.board_container);
-                    assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                        View boardContainer = view.findViewById(R.id.board_container);
+                        assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-                    // 4-player board is inflated, check that R.id.player_1, player_2, player_3,
-                    // player_4 are present
-                    View player1 = view.findViewById(R.id.player_1);
-                    View player2 = view.findViewById(R.id.player_2);
-                    View player3 = view.findViewById(R.id.player_3);
-                    View player4 = view.findViewById(R.id.player_4);
+                        // 4-player board is inflated, check that R.id.player_1, player_2, player_3,
+                        // player_4 are present
+                        View player1 = view.findViewById(R.id.player_1);
+                        View player2 = view.findViewById(R.id.player_2);
+                        View player3 = view.findViewById(R.id.player_3);
+                        View player4 = view.findViewById(R.id.player_4);
 
-                    assertNotNull(player1);
-                    assertNotNull(player2);
-                    assertNotNull(player3);
-                    assertNotNull(player4);
+                        assertNotNull(player1);
+                        assertNotNull(player2);
+                        assertNotNull(player3);
+                        assertNotNull(player4);
 
-                    // Verify starting life totals are 40
-                    TextView life1 = player1.findViewById(R.id.tv_life_count);
-                    TextView life2 = player2.findViewById(R.id.tv_life_count);
-                    assertEquals("40", life1.getText().toString());
-                    assertEquals("40", life2.getText().toString());
+                        // Verify starting life totals are 40
+                        TextView life1 = player1.findViewById(R.id.tv_life_count);
+                        TextView life2 = player2.findViewById(R.id.tv_life_count);
+                        assertEquals("40", life1.getText().toString());
+                        assertEquals("40", life2.getText().toString());
 
-                    // Tap PLUS button for player 1
-                    View btnPlus1 = player1.findViewById(R.id.btn_plus);
-                    assertNotNull(btnPlus1);
-                    btnPlus1.performClick();
+                        // Tap PLUS button for player 1
+                        View btnPlus1 = player1.findViewById(R.id.btn_plus);
+                        assertNotNull(btnPlus1);
+                        btnPlus1.performClick();
 
-                    // Tap MINUS button for player 2
-                    View btnMinus2 = player2.findViewById(R.id.btn_minus);
-                    assertNotNull(btnMinus2);
-                    btnMinus2.performClick();
-                });
+                        // Tap MINUS button for player 2
+                        View btnMinus2 = player2.findViewById(R.id.btn_minus);
+                        assertNotNull(btnMinus2);
+                        btnMinus2.performClick();
+                    });
 
-        // 3. Verify life totals are updated accordingly
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View player1 = view.findViewById(R.id.player_1);
-                    View player2 = view.findViewById(R.id.player_2);
+            // 3. Verify life totals are updated accordingly
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        View player1 = view.findViewById(R.id.player_1);
+                        View player2 = view.findViewById(R.id.player_2);
 
-                    TextView life1 = player1.findViewById(R.id.tv_life_count);
-                    TextView life2 = player2.findViewById(R.id.tv_life_count);
+                        TextView life1 = player1.findViewById(R.id.tv_life_count);
+                        TextView life2 = player2.findViewById(R.id.tv_life_count);
 
-                    assertEquals("41", life1.getText().toString());
-                    assertEquals("39", life2.getText().toString());
-                });
+                        assertEquals("41", life1.getText().toString());
+                        assertEquals("39", life2.getText().toString());
+                    });
+        }
     }
 
     @Test
     public void testNewGameResetActionReturnsToSetupWithPrefilledValues() {
-        FragmentScenario<MtgLifeFragment> scenario =
-                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-        // 1. Enter non-default setup, e.g., 3 players, 30 life, and start game
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    EditText playersInput = view.findViewById(R.id.players_input);
-                    EditText lifeInput = view.findViewById(R.id.life_input);
-                    playersInput.setText("3");
-                    lifeInput.setText("30");
+            // 1. Enter non-default setup, e.g., 3 players, 30 life, and start game
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        EditText playersInput = view.findViewById(R.id.players_input);
+                        EditText lifeInput = view.findViewById(R.id.life_input);
+                        playersInput.setText("3");
+                        lifeInput.setText("30");
 
-                    Button startButton = view.findViewById(R.id.start_game_button);
-                    startButton.performClick();
-                });
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        startButton.performClick();
+                    });
 
-        // 2. Verify we are playing 3 players game
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View setupContent = view.findViewById(R.id.setup_content);
-                    assertEquals(View.GONE, setupContent.getVisibility());
+            // 2. Verify we are playing 3 players game
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertEquals(View.GONE, setupContent.getVisibility());
 
-                    View boardContainer = view.findViewById(R.id.board_container);
-                    assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                        View boardContainer = view.findViewById(R.id.board_container);
+                        assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-                    View player1 = view.findViewById(R.id.player_1);
-                    View player3 = view.findViewById(R.id.player_3);
-                    assertNotNull(player1);
-                    assertNotNull(player3);
+                        View player1 = view.findViewById(R.id.player_1);
+                        View player3 = view.findViewById(R.id.player_3);
+                        assertNotNull(player1);
+                        assertNotNull(player3);
 
-                    TextView life1 = player1.findViewById(R.id.tv_life_count);
-                    assertEquals("30", life1.getText().toString());
-                });
+                        TextView life1 = player1.findViewById(R.id.tv_life_count);
+                        assertEquals("30", life1.getText().toString());
+                    });
 
-        // 3. Trigger app-bar "New Game" menu action (action_new_game)
-        scenario.onFragment(
-                fragment -> {
-                    org.robolectric.fakes.RoboMenuItem resetMenuItem =
-                            new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
-                    fragment.onMenuItemSelected(resetMenuItem);
-                });
+            // 3. Trigger app-bar "New Game" menu action (action_new_game)
+            scenario.onFragment(
+                    fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+                    });
 
-        // 4. Verify we are back on the setup screen and inputs are prefilled with last-used values
-        // (3 and 30)
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View setupContent = view.findViewById(R.id.setup_content);
-                    assertEquals(View.VISIBLE, setupContent.getVisibility());
+            // 4. Verify we are back on the setup screen and inputs are prefilled with last-used
+            // values
+            // (3 and 30)
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertEquals(View.VISIBLE, setupContent.getVisibility());
 
-                    View boardContainer = view.findViewById(R.id.board_container);
-                    assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                        View boardContainer = view.findViewById(R.id.board_container);
+                        assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-                    EditText playersInput = view.findViewById(R.id.players_input);
-                    EditText lifeInput = view.findViewById(R.id.life_input);
-                    assertEquals("3", playersInput.getText().toString());
-                    assertEquals("30", lifeInput.getText().toString());
-                });
+                        EditText playersInput = view.findViewById(R.id.players_input);
+                        EditText lifeInput = view.findViewById(R.id.life_input);
+                        assertEquals("3", playersInput.getText().toString());
+                        assertEquals("30", lifeInput.getText().toString());
+                    });
+        }
     }
 
     @Test
     public void testTappingOutsideSetupCardDismissesOverlayWhenGameIsActive() {
-        FragmentScenario<MtgLifeFragment> scenario =
-                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-        // 1. Start a game with default settings
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    Button startButton = view.findViewById(R.id.start_game_button);
-                    startButton.performClick();
-                });
+            // 1. Start a game with default settings
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        startButton.performClick();
+                    });
 
-        // 2. Go back to setup screen via menu action
-        scenario.onFragment(
-                fragment -> {
-                    org.robolectric.fakes.RoboMenuItem resetMenuItem =
-                            new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
-                    fragment.onMenuItemSelected(resetMenuItem);
-                });
+            // 2. Go back to setup screen via menu action
+            scenario.onFragment(
+                    fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+                    });
 
-        // 3. Verify setup overlay is visible
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View setupOverlay = view.findViewById(R.id.setup_overlay);
-                    assertEquals(View.VISIBLE, setupOverlay.getVisibility());
-                });
+            // 3. Verify setup overlay is visible
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        View setupOverlay = view.findViewById(R.id.setup_overlay);
+                        assertEquals(View.VISIBLE, setupOverlay.getVisibility());
+                    });
 
-        // 4. Tap the overlay (clicking outside the card)
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View setupOverlay = view.findViewById(R.id.setup_overlay);
-                    setupOverlay.performClick();
-                });
+            // 4. Tap the overlay (clicking outside the card)
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        View setupOverlay = view.findViewById(R.id.setup_overlay);
+                        setupOverlay.performClick();
+                    });
 
-        // 5. Verify setup overlay is now GONE (modal dismissed/escaped)
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    View setupOverlay = view.findViewById(R.id.setup_overlay);
-                    assertEquals(View.GONE, setupOverlay.getVisibility());
-                });
+            // 5. Verify setup overlay is now GONE (modal dismissed/escaped)
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        View setupOverlay = view.findViewById(R.id.setup_overlay);
+                        assertEquals(View.GONE, setupOverlay.getVisibility());
+                    });
+        }
     }
 
     @Test
     public void testCommanderDamageDialogHalfTapZonesUpdateSummary() {
-        FragmentScenario<MtgLifeFragment> scenario =
-                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme);
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-        scenario.onFragment(
-                fragment -> {
-                    View view = fragment.getView();
-                    Button startButton = view.findViewById(R.id.start_game_button);
-                    startButton.performClick();
-                });
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        startButton.performClick();
+                    });
 
-        scenario.onFragment(
-                fragment -> {
-                    View player1 = fragment.requireView().findViewById(R.id.player_1);
-                    View commanderGrid = player1.findViewById(R.id.commander_damage_grid);
-                    assertNotNull(commanderGrid);
-                    try {
-                        java.lang.reflect.Method showDialogMethod =
-                                MtgLifeFragment.class.getDeclaredMethod(
-                                        "showCommanderDamageDialog", int.class);
-                        showDialogMethod.setAccessible(true);
-                        showDialogMethod.invoke(fragment, 0);
-                    } catch (ReflectiveOperationException e) {
-                        throw new AssertionError(e);
-                    }
-                    Shadows.shadowOf(Looper.getMainLooper()).idle();
+            scenario.onFragment(
+                    fragment -> {
+                        View player1 = fragment.requireView().findViewById(R.id.player_1);
+                        View commanderGrid = player1.findViewById(R.id.commander_damage_grid);
+                        assertNotNull(commanderGrid);
+                        try {
+                            java.lang.reflect.Method showDialogMethod =
+                                    MtgLifeFragment.class.getDeclaredMethod(
+                                            "showCommanderDamageDialog", int.class);
+                            showDialogMethod.setAccessible(true);
+                            showDialogMethod.invoke(fragment, 0);
+                        } catch (ReflectiveOperationException e) {
+                            throw new AssertionError(e);
+                        }
+                        Shadows.shadowOf(Looper.getMainLooper()).idle();
 
-                    Dialog dialog = ShadowDialog.getLatestDialog();
-                    assertNotNull(dialog);
-                    assertTrue(dialog.isShowing());
+                        Dialog dialog = ShadowDialog.getLatestDialog();
+                        assertNotNull(dialog);
+                        assertTrue(dialog.isShowing());
+                        assertNotNull(dialog.getWindow());
 
-                    View decorView = dialog.getWindow().getDecorView();
-                    View incrementZone =
-                            findViewWithContentDescription(
-                                    decorView,
-                                    fragment.getString(
-                                            R.string.mtg_commander_damage_increase_desc, 2, 1));
-                    View decrementZone =
-                            findViewWithContentDescription(
-                                    decorView,
-                                    fragment.getString(
-                                            R.string.mtg_commander_damage_decrease_desc, 2, 1));
+                        View decorView = dialog.getWindow().getDecorView();
+                        View incrementZone =
+                                findViewWithContentDescription(
+                                        decorView,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_increase_desc, 2, 1));
+                        View decrementZone =
+                                findViewWithContentDescription(
+                                        decorView,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_decrease_desc, 2, 1));
 
-                    assertNotNull(incrementZone);
-                    assertNotNull(decrementZone);
+                        assertNotNull(incrementZone);
+                        assertNotNull(decrementZone);
 
-                    incrementZone.performClick();
-                    incrementZone.performClick();
-                    decrementZone.performClick();
+                        incrementZone.performClick();
+                        incrementZone.performClick();
+                        decrementZone.performClick();
 
-                    View updatedSummary =
-                            findViewWithContentDescription(
-                                    commanderGrid,
-                                    fragment.getString(
-                                            R.string.mtg_commander_damage_cell_desc, 2, 1, 1));
-                    assertNotNull(updatedSummary);
-                });
+                        View updatedSummary =
+                                findViewWithContentDescription(
+                                        commanderGrid,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_cell_desc, 2, 1, 1));
+                        assertNotNull(updatedSummary);
+                    });
+        }
     }
 
     private static View findViewWithContentDescription(View root, CharSequence contentDescription) {
@@ -298,14 +308,14 @@ public class MtgLifeFragmentTest {
             return null;
         }
         CharSequence rootDescription = root.getContentDescription();
-        if (rootDescription != null && rootDescription.toString().contentEquals(contentDescription)) {
+        if (rootDescription != null
+                && rootDescription.toString().contentEquals(contentDescription)) {
             return root;
         }
         if (root instanceof android.view.ViewGroup rootGroup) {
             for (int i = 0; i < rootGroup.getChildCount(); i++) {
                 View match =
-                        findViewWithContentDescription(
-                                rootGroup.getChildAt(i), contentDescription);
+                        findViewWithContentDescription(rootGroup.getChildAt(i), contentDescription);
                 if (match != null) {
                     return match;
                 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -364,7 +364,8 @@ public class MtgLifeFragmentTest {
                         // Col 0: Player 1 (source seat 0) -> visible
                         // Col 1: Player 2 (source seat 1) -> visible
                         // Col 2: Player 5 (source seat 4, self) -> invisible
-                        android.widget.LinearLayout row0 = (android.widget.LinearLayout) dialogContent.getChildAt(0);
+                        android.widget.LinearLayout row0 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(0);
                         View cell0 = row0.getChildAt(0);
                         View cell1 = row0.getChildAt(1);
                         View cell2 = row0.getChildAt(2);
@@ -374,10 +375,16 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.INVISIBLE, cell2.getVisibility());
 
                         // Verify increment zones exist in cell0 and cell1
-                        View incZone0 = findViewWithContentDescription(
-                                cell0, fragment.getString(R.string.mtg_commander_damage_increase_desc, 1, 5));
-                        View incZone1 = findViewWithContentDescription(
-                                cell1, fragment.getString(R.string.mtg_commander_damage_increase_desc, 2, 5));
+                        View incZone0 =
+                                findViewWithContentDescription(
+                                        cell0,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_increase_desc, 1, 5));
+                        View incZone1 =
+                                findViewWithContentDescription(
+                                        cell1,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_increase_desc, 2, 5));
                         assertNotNull(incZone0);
                         assertNotNull(incZone1);
 
@@ -385,7 +392,8 @@ public class MtgLifeFragmentTest {
                         // Col 0: Player 3 (source seat 2) -> visible
                         // Col 1: Player 4 (source seat 3) -> visible
                         // Col 2: Spacer (seat 5) -> invisible
-                        android.widget.LinearLayout row1 = (android.widget.LinearLayout) dialogContent.getChildAt(1);
+                        android.widget.LinearLayout row1 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(1);
                         View cell3 = row1.getChildAt(0);
                         View cell4 = row1.getChildAt(1);
                         View cell5 = row1.getChildAt(2);
@@ -394,10 +402,16 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.VISIBLE, cell4.getVisibility());
                         assertEquals(View.INVISIBLE, cell5.getVisibility());
 
-                        View incZone3 = findViewWithContentDescription(
-                                cell3, fragment.getString(R.string.mtg_commander_damage_increase_desc, 3, 5));
-                        View incZone4 = findViewWithContentDescription(
-                                cell4, fragment.getString(R.string.mtg_commander_damage_increase_desc, 4, 5));
+                        View incZone3 =
+                                findViewWithContentDescription(
+                                        cell3,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_increase_desc, 3, 5));
+                        View incZone4 =
+                                findViewWithContentDescription(
+                                        cell4,
+                                        fragment.getString(
+                                                R.string.mtg_commander_damage_increase_desc, 4, 5));
                         assertNotNull(incZone3);
                         assertNotNull(incZone4);
                     });

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -357,7 +357,7 @@ public class MtgLifeFragmentTest {
 
                         View decorView = dialog.getWindow().getDecorView();
                         android.widget.LinearLayout dialogContent =
-                                (android.widget.LinearLayout) findDialogContent(decorView);
+                                decorView.findViewWithTag("commander_dialog_content");
                         assertNotNull(dialogContent);
 
                         // Verify that row 0 has the expected cells:
@@ -402,28 +402,6 @@ public class MtgLifeFragmentTest {
                         assertNotNull(incZone4);
                     });
         }
-    }
-
-    private static View findDialogContent(View root) {
-        if (root instanceof android.widget.LinearLayout layout) {
-            if (layout.getOrientation() == android.widget.LinearLayout.VERTICAL && layout.getChildCount() == 2) {
-                View child = layout.getChildAt(0);
-                if (child instanceof android.widget.LinearLayout horizontalLayout) {
-                    if (horizontalLayout.getOrientation() == android.widget.LinearLayout.HORIZONTAL) {
-                        return layout;
-                    }
-                }
-            }
-        }
-        if (root instanceof android.view.ViewGroup group) {
-            for (int i = 0; i < group.getChildCount(); i++) {
-                View match = findDialogContent(group.getChildAt(i));
-                if (match != null) {
-                    return match;
-                }
-            }
-        }
-        return null;
     }
 
     private static View findViewWithContentDescription(View root, CharSequence contentDescription) {

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -66,6 +66,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         Button startButton = view.findViewById(R.id.start_game_button);
                         assertNotNull(startButton);
                         startButton.performClick();
@@ -115,9 +116,12 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         View player1 = view.findViewById(R.id.player_1);
                         View player2 = view.findViewById(R.id.player_2);
 
+                        assertNotNull(player1);
+                        assertNotNull(player2);
                         TextView life1 = player1.findViewById(R.id.tv_life_count);
                         TextView life2 = player2.findViewById(R.id.tv_life_count);
 
@@ -136,6 +140,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         EditText playersInput = view.findViewById(R.id.players_input);
                         EditText lifeInput = view.findViewById(R.id.life_input);
                         playersInput.setText("3");
@@ -203,6 +208,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         Button startButton = view.findViewById(R.id.start_game_button);
                         startButton.performClick();
                     });
@@ -219,6 +225,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         View setupOverlay = view.findViewById(R.id.setup_overlay);
                         assertEquals(View.VISIBLE, setupOverlay.getVisibility());
                     });
@@ -227,6 +234,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         View setupOverlay = view.findViewById(R.id.setup_overlay);
                         setupOverlay.performClick();
                     });
@@ -235,6 +243,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         View setupOverlay = view.findViewById(R.id.setup_overlay);
                         assertEquals(View.GONE, setupOverlay.getVisibility());
                     });
@@ -249,6 +258,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
+                        assertNotNull(view);
                         Button startButton = view.findViewById(R.id.start_game_button);
                         startButton.performClick();
                     });
@@ -256,6 +266,7 @@ public class MtgLifeFragmentTest {
             scenario.onFragment(
                     fragment -> {
                         View player1 = fragment.requireView().findViewById(R.id.player_1);
+                        assertNotNull(player1);
                         View commanderGrid = player1.findViewById(R.id.commander_damage_grid);
                         assertNotNull(commanderGrid);
                         try {

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -314,6 +314,118 @@ public class MtgLifeFragmentTest {
         }
     }
 
+    @Test
+    public void testFivePlayerCommanderDamageLayoutForPlayer5MatchesFragment() {
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
+
+            // 1. Enter 5 players setup and start game
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+                        EditText playersInput = view.findViewById(R.id.players_input);
+                        EditText lifeInput = view.findViewById(R.id.life_input);
+                        playersInput.setText("5");
+                        lifeInput.setText("40");
+
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        startButton.performClick();
+                    });
+
+            // 2. Open commander damage dialog for player 5 (seat 4)
+            scenario.onFragment(
+                    fragment -> {
+                        View player5 = fragment.requireView().findViewById(R.id.player_5);
+                        View commanderGrid = player5.findViewById(R.id.commander_damage_grid);
+                        assertNotNull(commanderGrid);
+                        try {
+                            java.lang.reflect.Method showDialogMethod =
+                                    MtgLifeFragment.class.getDeclaredMethod(
+                                            "showCommanderDamageDialog", int.class);
+                            showDialogMethod.setAccessible(true);
+                            showDialogMethod.invoke(fragment, 4);
+                        } catch (ReflectiveOperationException e) {
+                            throw new AssertionError(e);
+                        }
+                        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+                        Dialog dialog = ShadowDialog.getLatestDialog();
+                        assertNotNull(dialog);
+                        assertTrue(dialog.isShowing());
+                        assertNotNull(dialog.getWindow());
+
+                        View decorView = dialog.getWindow().getDecorView();
+                        android.widget.LinearLayout dialogContent =
+                                (android.widget.LinearLayout) findDialogContent(decorView);
+                        assertNotNull(dialogContent);
+
+                        // Verify that row 0 has the expected cells:
+                        // Col 0: Player 1 (source seat 0) -> visible
+                        // Col 1: Player 2 (source seat 1) -> visible
+                        // Col 2: Player 5 (source seat 4, self) -> invisible
+                        android.widget.LinearLayout row0 = (android.widget.LinearLayout) dialogContent.getChildAt(0);
+                        View cell0 = row0.getChildAt(0);
+                        View cell1 = row0.getChildAt(1);
+                        View cell2 = row0.getChildAt(2);
+
+                        assertEquals(View.VISIBLE, cell0.getVisibility());
+                        assertEquals(View.VISIBLE, cell1.getVisibility());
+                        assertEquals(View.INVISIBLE, cell2.getVisibility());
+
+                        // Verify increment zones exist in cell0 and cell1
+                        View incZone0 = findViewWithContentDescription(
+                                cell0, fragment.getString(R.string.mtg_commander_damage_increase_desc, 1, 5));
+                        View incZone1 = findViewWithContentDescription(
+                                cell1, fragment.getString(R.string.mtg_commander_damage_increase_desc, 2, 5));
+                        assertNotNull(incZone0);
+                        assertNotNull(incZone1);
+
+                        // Verify that row 1 has the expected cells:
+                        // Col 0: Player 3 (source seat 2) -> visible
+                        // Col 1: Player 4 (source seat 3) -> visible
+                        // Col 2: Spacer (seat 5) -> invisible
+                        android.widget.LinearLayout row1 = (android.widget.LinearLayout) dialogContent.getChildAt(1);
+                        View cell3 = row1.getChildAt(0);
+                        View cell4 = row1.getChildAt(1);
+                        View cell5 = row1.getChildAt(2);
+
+                        assertEquals(View.VISIBLE, cell3.getVisibility());
+                        assertEquals(View.VISIBLE, cell4.getVisibility());
+                        assertEquals(View.INVISIBLE, cell5.getVisibility());
+
+                        View incZone3 = findViewWithContentDescription(
+                                cell3, fragment.getString(R.string.mtg_commander_damage_increase_desc, 3, 5));
+                        View incZone4 = findViewWithContentDescription(
+                                cell4, fragment.getString(R.string.mtg_commander_damage_increase_desc, 4, 5));
+                        assertNotNull(incZone3);
+                        assertNotNull(incZone4);
+                    });
+        }
+    }
+
+    private static View findDialogContent(View root) {
+        if (root instanceof android.widget.LinearLayout layout) {
+            if (layout.getOrientation() == android.widget.LinearLayout.VERTICAL && layout.getChildCount() == 2) {
+                View child = layout.getChildAt(0);
+                if (child instanceof android.widget.LinearLayout horizontalLayout) {
+                    if (horizontalLayout.getOrientation() == android.widget.LinearLayout.HORIZONTAL) {
+                        return layout;
+                    }
+                }
+            }
+        }
+        if (root instanceof android.view.ViewGroup group) {
+            for (int i = 0; i < group.getChildCount(); i++) {
+                View match = findDialogContent(group.getChildAt(i));
+                if (match != null) {
+                    return match;
+                }
+            }
+        }
+        return null;
+    }
+
     private static View findViewWithContentDescription(View root, CharSequence contentDescription) {
         if (root == null) {
             return null;

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -219,26 +219,31 @@ public class MtgLifeViewModelTest {
     @Test
     public void testCommanderDamageIncrementAndDecrement() throws Exception {
         viewModel.validateAndStartGame("2", "40", true);
-        
+
         // Increment player 0 damage from source player 1
         viewModel.incrementCommanderDamage(0, 1);
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(1, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
+        assertEquals(39, state.getPlayers().getFirst().getLifeTotal());
+        assertEquals(40, state.getPlayers().get(1).getLifeTotal());
 
         // Self damage changes should be ignored
         viewModel.incrementCommanderDamage(0, 0);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().getFirst().getAmount());
+        assertEquals(39, state.getPlayers().getFirst().getLifeTotal());
 
         // Decrement player 0 damage from source player 1
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
+        assertEquals(40, state.getPlayers().getFirst().getLifeTotal());
 
         // Decrement below 0 floor should be ignored
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
+        assertEquals(40, state.getPlayers().getFirst().getLifeTotal());
     }
 
     @Test

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -190,4 +190,103 @@ public class MtgLifeViewModelTest {
         assertEquals(90, state.getPlayers().get(4).getRotationDegrees());
         assertEquals(270, state.getPlayers().get(5).getRotationDegrees());
     }
+
+    @Test
+    public void testDefaultCommanderDamageState() throws Exception {
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isCommanderDamageEnabled());
+
+        viewModel.validateAndStartGame("2", "40", true);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isCommanderDamageEnabled());
+
+        // Check that player 0 has 2 commander damage items (for player 0 and player 1)
+        List<CommanderDamageUiModel> damages = state.getPlayers().get(0).getCommanderDamages();
+        assertEquals(2, damages.size());
+
+        // Self damage should be self = true, amount = 0
+        assertTrue(damages.get(0).isSelf());
+        assertEquals(0, damages.get(0).getAmount());
+
+        // Opponent damage should be self = false, amount = 0
+        assertFalse(damages.get(1).isSelf());
+        assertEquals(0, damages.get(1).getAmount());
+    }
+
+    @Test
+    public void testCommanderDamageIncrementAndDecrement() throws Exception {
+        viewModel.validateAndStartGame("2", "40", true);
+        
+        // Increment player 0 damage from source player 1
+        viewModel.incrementCommanderDamage(0, 1);
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(1, state.getPlayers().get(0).getCommanderDamages().get(1).getAmount());
+
+        // Self damage changes should be ignored
+        viewModel.incrementCommanderDamage(0, 0);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(0, state.getPlayers().get(0).getCommanderDamages().get(0).getAmount());
+
+        // Decrement player 0 damage from source player 1
+        viewModel.decrementCommanderDamage(0, 1);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(0, state.getPlayers().get(0).getCommanderDamages().get(1).getAmount());
+
+        // Decrement below 0 floor should be ignored
+        viewModel.decrementCommanderDamage(0, 1);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(0, state.getPlayers().get(0).getCommanderDamages().get(1).getAmount());
+    }
+
+    @Test
+    public void testCommanderDamageVisibilityByPlayerCount() throws Exception {
+        // Player count = 1: strip must be hidden even if enabled
+        viewModel.validateAndStartGame("1", "40", true);
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.getPlayers().get(0).isCommanderDamageVisible());
+
+        // Player count = 2: strip should be visible
+        viewModel.validateAndStartGame("2", "40", true);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.getPlayers().get(0).isCommanderDamageVisible());
+
+        // If explicitly disabled: strip should be hidden
+        viewModel.validateAndStartGame("2", "40", false);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.getPlayers().get(0).isCommanderDamageVisible());
+    }
+
+    @Test
+    public void testLethalCommanderDamageTreatment() throws Exception {
+        viewModel.validateAndStartGame("2", "40", true);
+
+        // Increment to 20
+        for (int i = 0; i < 20; i++) {
+            viewModel.incrementCommanderDamage(0, 1);
+        }
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.getPlayers().get(0).getCommanderDamages().get(1).isLethal());
+
+        // 21st point -> lethal
+        viewModel.incrementCommanderDamage(0, 1);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        CommanderDamageUiModel model = state.getPlayers().get(0).getCommanderDamages().get(1);
+        assertTrue(model.isLethal());
+        assertEquals(R.color.secondAccent, model.getBackgroundColorRes());
+        assertEquals(android.R.color.white, model.getForegroundColorRes());
+    }
+
+    @Test
+    public void testNewGamePreservesToggle() throws Exception {
+        // Disable commander damage and start game
+        viewModel.validateAndStartGame("3", "40", false);
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.isCommanderDamageEnabled());
+
+        // Reset to setup
+        viewModel.resetToSetup();
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isShowingSetup());
+        assertFalse(state.isCommanderDamageEnabled());
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -9,6 +9,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.SavedStateHandle;
 import com.nicue.onetwo.LiveDataTestUtil;
 import com.nicue.onetwo.R;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -201,7 +202,7 @@ public class MtgLifeViewModelTest {
         assertTrue(state.isCommanderDamageEnabled());
 
         // Check that player 0 has 2 commander damage items (for player 0 and player 1)
-        List<CommanderDamageUiModel> damages = state.getPlayers().get(0).getCommanderDamages();
+        List<CommanderDamageUiModel> damages = state.getPlayers().getFirst().getCommanderDamages();
         assertEquals(2, damages.size());
 
         // Self damage should be self = true, amount = 0
@@ -220,22 +221,22 @@ public class MtgLifeViewModelTest {
         // Increment player 0 damage from source player 1
         viewModel.incrementCommanderDamage(0, 1);
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertEquals(1, state.getPlayers().get(0).getCommanderDamages().get(1).getAmount());
+        assertEquals(1, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
 
         // Self damage changes should be ignored
         viewModel.incrementCommanderDamage(0, 0);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertEquals(0, state.getPlayers().get(0).getCommanderDamages().get(0).getAmount());
+        assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().getFirst().getAmount());
 
         // Decrement player 0 damage from source player 1
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertEquals(0, state.getPlayers().get(0).getCommanderDamages().get(1).getAmount());
+        assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
 
         // Decrement below 0 floor should be ignored
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertEquals(0, state.getPlayers().get(0).getCommanderDamages().get(1).getAmount());
+        assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
     }
 
     @Test
@@ -243,17 +244,17 @@ public class MtgLifeViewModelTest {
         // Player count = 1: strip must be hidden even if enabled
         viewModel.validateAndStartGame("1", "40", true);
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertFalse(state.getPlayers().get(0).isCommanderDamageVisible());
+        assertFalse(state.getPlayers().getFirst().isCommanderDamageVisible());
 
         // Player count = 2: strip should be visible
         viewModel.validateAndStartGame("2", "40", true);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertTrue(state.getPlayers().get(0).isCommanderDamageVisible());
+        assertTrue(state.getPlayers().getFirst().isCommanderDamageVisible());
 
         // If explicitly disabled: strip should be hidden
         viewModel.validateAndStartGame("2", "40", false);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertFalse(state.getPlayers().get(0).isCommanderDamageVisible());
+        assertFalse(state.getPlayers().getFirst().isCommanderDamageVisible());
     }
 
     @Test
@@ -265,12 +266,12 @@ public class MtgLifeViewModelTest {
             viewModel.incrementCommanderDamage(0, 1);
         }
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertFalse(state.getPlayers().get(0).getCommanderDamages().get(1).isLethal());
+        assertFalse(state.getPlayers().getFirst().getCommanderDamages().get(1).isLethal());
 
         // 21st point -> lethal
         viewModel.incrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        CommanderDamageUiModel model = state.getPlayers().get(0).getCommanderDamages().get(1);
+        CommanderDamageUiModel model = state.getPlayers().getFirst().getCommanderDamages().get(1);
         assertTrue(model.isLethal());
         assertEquals(R.color.secondAccent, model.getBackgroundColorRes());
         assertEquals(android.R.color.white, model.getForegroundColorRes());

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -75,7 +75,7 @@ public class MtgLifeViewModelTest {
         assertEquals(R.string.mtg_setup_players_error, (int) state.getPlayersErrorResId());
         assertNull(state.getLifeErrorResId());
 
-        // Non-integer player count
+        // Noninteger player count
         viewModel.validateAndStartGame("abc", "20");
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertTrue(state.isShowingSetup());
@@ -141,6 +141,8 @@ public class MtgLifeViewModelTest {
     public void testIncrementAndDecrementLife() throws Exception {
         viewModel.validateAndStartGame("2", "20");
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(20, state.getPlayers().get(0).getLifeTotal());
+        assertEquals(20, state.getPlayers().get(1).getLifeTotal());
 
         // Increment player 0 life
         viewModel.incrementLife(0);

--- a/docs/rfcs/2026-05-18-mtg-commander-damage.md
+++ b/docs/rfcs/2026-05-18-mtg-commander-damage.md
@@ -1,0 +1,263 @@
+# RFC: MTG Commander Damage
+
+- Status: Proposed
+- Date: 2026-05-18
+- Related: `docs/rfcs/2026-05-18-mtg-life-counter-fragment.md`
+
+## Summary
+
+Add commander-damage tracking to the existing MTG life counter. Each `LifePlayerUiModel` tile should render a compact commander-damage strip at the bottom, matching the placement in the provided reference. The strip tracks damage dealt to that player by each seat's commander and persists alongside life totals in the existing `MtgLifeViewModel` state.
+
+## Motivation
+
+The life counter now supports shared-screen MTG play, but Commander games still require players to track a second loss condition outside the app. Keeping commander damage inside the same tile avoids paper tracking and keeps all table-state interactions in one place.
+
+This is a natural follow-up to the original life-counter RFC, which explicitly left commander damage out of v1.
+
+## Goals
+
+- Add per-player commander-damage tracking to the MTG life screen.
+- Render commander damage inside each player tile, anchored at the bottom of the tile.
+- Keep the life total visually dominant and the commander-damage UI clearly secondary.
+- Preserve commander-damage state across view recreation and configuration changes.
+- Support the same 1 to 6 player range as the existing MTG life feature.
+- Make the 21-damage Commander loss threshold easy to notice.
+
+## Non-Goals
+
+- Poison, energy, experience, or other side counters.
+- Persistent saved games outside the current in-memory plus `SavedStateHandle` session model.
+- Automatic winner detection, player elimination flows, or lockout behavior after 21 damage.
+- Partner/background/multiple-commander tracking per player in v1.
+- Renaming players or adding deck metadata in this RFC.
+
+## Product Decisions
+
+### Scope
+
+This is an extension of the existing MTG life fragment, not a separate top-level feature.
+
+### Visibility
+
+Add a `Commander Damage` toggle to the setup state, defaulting to `on`. When enabled, the play board shows commander-damage controls in every tile. When disabled, the board keeps the current life-only layout.
+
+Why:
+
+- the MTG life feature is useful for both Commander and non-Commander games
+- always-on commander UI would add noise for formats that do not use it
+- a setup toggle keeps the play experience explicit instead of inferring format from starting life
+
+### Tile Placement
+
+Commander damage belongs inside `LifePlayerUiModel` as bottom-of-tile content, below the large life total and below the primary `+` and `-` life interactions. It should not float outside the player cell and should not require opening a separate screen.
+
+## UX Proposal
+
+### Setup State
+
+Extend the current setup form with:
+
+- label: `Commander Damage`
+- control: `MaterialSwitch`
+- default: `on`
+
+The rest of the setup flow stays unchanged.
+
+### Play State
+
+Each player tile continues to show:
+
+- large centered life total
+- tap targets for `-1` and `+1` life
+
+When commander damage is enabled, the tile also shows a compact damage grid pinned to the bottom of the tile.
+
+Each commander-damage cell represents:
+
+- defender: the tile's player
+- source: one seat in the current game
+- value: total commander damage dealt by that source to that defender
+
+To keep the layout stable, render one cell per seat, including self:
+
+- self cell: disabled, labeled `me`
+- opponent cells: interactive, numeric, starting at `0`
+
+This mirrors the provided reference while avoiding gaps in the grid.
+
+### Interaction Model
+
+Life interactions stay exactly as they are today.
+
+Commander-damage interactions should be compact:
+
+- tap a commander-damage cell to increment that source's damage by `1`
+- long-press a commander-damage cell to decrement by `1`, with a floor of `0`
+- self cells do nothing
+- reaching `21` does not lock the value; users can decrement back to `20` or lower to correct mistakes
+
+Why this interaction:
+
+- it fits the limited bottom-of-tile space
+- it avoids adding separate `+` and `-` chrome for every opponent
+- it keeps the primary life controls visually dominant
+
+### Visual Treatment
+
+- The commander-damage strip should be clearly smaller than the life controls.
+- Use a rounded container or small card treatment similar to the reference.
+- Opponent cells should use the source player's seat color family so the source mapping is consistent across the board.
+- The self cell should use a neutral outlined or muted treatment rather than a player color.
+- At `21` or more, the relevant commander-damage cell should switch to an error or warning treatment.
+
+## Layout Strategy
+
+Update `app/src/main/res/layout/life_player_cell.xml` instead of introducing a second player-cell layout.
+
+Recommended structure:
+
+- keep the current centered life total and left/right life buttons
+- add a bottom-aligned commander-damage container inside `inner_player_layout`
+- constrain the life-total area above that container so the new strip has reserved space
+
+Grid recommendation by player count:
+
+| Players | Commander grid |
+| --- | --- |
+| 1 | hidden |
+| 2 | 1 x 2 |
+| 3 | 2 x 2 |
+| 4 | 2 x 2 |
+| 5 | 2 x 3 |
+| 6 | 2 x 3 |
+
+Implementation note:
+
+- Use a lightweight child container that can be rebuilt from binding code, such as `GridLayout` or a small included layout set.
+- Keep the grid within the already rotated `inner_player_layout` so the strip follows the tile orientation automatically.
+
+## Architecture
+
+### State Model
+
+Extend `MtgLifeViewModel` saved state with:
+
+- `KEY_COMMANDER_DAMAGE_ENABLED`
+- `KEY_COMMANDER_DAMAGE_MATRIX`
+
+Recommended persisted structure:
+
+- `boolean commanderDamageEnabled`
+- `List<ArrayList<Integer>> commanderDamageMatrix`
+
+Matrix semantics:
+
+- outer index: defender seat
+- inner index: source seat
+- `matrix[defender][source]` is commander damage dealt by `source` to `defender`
+- self entries always remain `0`
+
+Initialize the matrix when a new game starts:
+
+- size `N x N`
+- all values `0`
+
+Reset behavior:
+
+- `New Game` returns to setup and preserves the last-used commander-damage toggle just as the screen already preserves player count and starting life
+
+### UI Models
+
+Extend `LifePlayerUiModel` rather than pushing commander-damage logic into the fragment.
+
+Recommended shape:
+
+- `LifePlayerUiModel`
+  - existing fields
+  - `boolean commanderDamageVisible`
+  - `List<CommanderDamageUiModel> commanderDamages`
+
+- `CommanderDamageUiModel`
+  - `sourceSeatIndex`
+  - `amount`
+  - `boolean self`
+  - `boolean lethal`
+  - `int backgroundColorRes`
+  - `int foregroundColorRes`
+
+This keeps the fragment focused on rendering and click wiring, matching the existing architecture where seat colors and rotations are already derived in `MtgLifeViewModel`.
+
+### Fragment Responsibilities
+
+`MtgLifeFragment` should:
+
+- keep binding the current board template per player count
+- bind the existing life buttons and life total exactly as today
+- show or hide the commander-damage container per player
+- inflate or bind commander-damage cells from `LifePlayerUiModel`
+- route tap and long-press events to `MtgLifeViewModel`
+
+### ViewModel Responsibilities
+
+`MtgLifeViewModel` should:
+
+- validate the new setup toggle input
+- create the commander-damage matrix on game start when enabled
+- expose commander-damage UI state inside each `LifePlayerUiModel`
+- increment and decrement commander damage for a specific defender/source pair
+- clamp commander damage at `0`
+- derive `lethal` once a source reaches `21` or more
+
+## Accessibility and Usability
+
+- Every commander-damage cell needs a content description in the form `Commander damage from player 3 to player 1: 7`.
+- The self cell should expose a description such as `Your own commander damage slot`.
+- Long-press decrement must have an accessibility fallback. Recommended approach: include a custom accessibility action for decrement on interactive commander-damage cells.
+- Do not rely on color alone to identify source seats; the order must remain stable and the content description must include player numbers.
+- The commander strip must not reduce life-button touch targets below 48dp.
+
+## Testing Plan
+
+Add or update local JVM and Robolectric coverage for:
+
+- `MtgLifeViewModelTest`
+  - new games initialize a zeroed commander-damage matrix when enabled
+  - disabling commander damage leaves player life state unchanged and hides commander UI
+  - tapping a source increments only the targeted defender/source entry
+  - decrement never goes below `0`
+  - self entries remain `0`
+  - `21` commander damage marks the entry as lethal
+  - `New Game` preserves the last-used commander-damage toggle
+
+- `MtgLifeFragmentTest`
+  - setup shows the commander-damage toggle with default `on`
+  - starting a commander-enabled game shows the bottom commander strip
+  - interactive commander cells increment on tap
+  - self cells are disabled
+  - commander-disabled games do not render the strip
+
+## Implementation Plan
+
+1. Extend setup state and strings with the commander-damage toggle.
+2. Add commander-damage saved-state keys and matrix logic to `MtgLifeViewModel`.
+3. Extend `LifePlayerUiModel` with commander-damage child state.
+4. Update `life_player_cell.xml` to reserve bottom space for the commander strip.
+5. Bind commander-damage cells in `MtgLifeFragment`, including tap and long-press handlers.
+6. Add lethal-state styling and accessibility actions.
+7. Add focused ViewModel and fragment tests.
+
+## Risks and Mitigations
+
+- The bottom strip could crowd small 5- and 6-player layouts.
+  - Mitigation: keep the commander UI compact, reserve a fixed bottom band, and auto-size the life total more aggressively when commander damage is enabled.
+- Long-press decrement is discoverable but not obvious.
+  - Mitigation: add a tooltip or helper text in the RFC implementation review if testing shows confusion, and always expose an accessibility decrement action.
+- Matrix indexing bugs are easy to introduce.
+  - Mitigation: keep defender/source semantics explicit in method names and cover them with focused unit tests.
+
+## Future Extensions
+
+- Optional per-player commander names.
+- Partner or multi-commander support.
+- Poison counters using the same bottom-of-tile secondary-state pattern.
+- Explicit player-dead highlighting when life reaches `0` or commander damage reaches `21`.

--- a/docs/rfcs/2026-05-18-mtg-commander-damage.md
+++ b/docs/rfcs/2026-05-18-mtg-commander-damage.md
@@ -6,11 +6,11 @@
 
 ## Summary
 
-Add commander-damage tracking to the existing MTG life counter. Each `LifePlayerUiModel` tile should render a compact commander-damage strip at the bottom, matching the placement in the provided reference. The strip tracks damage dealt to that player by each seat's commander and persists alongside life totals in the existing `MtgLifeViewModel` state.
+Add commander-damage tracking to the existing MTG life counter. Each `LifePlayerUiModel` tile should render a compact commander-damage strip at the bottom, matching the placement in the provided reference. The strip acts as a summary for damage dealt to that player by each seat's commander, and tapping it opens a modal editor where the values can be adjusted. Commander-damage state persists alongside life totals in the existing `MtgLifeViewModel` state.
 
 ## Motivation
 
-The life counter now supports shared-screen MTG play, but Commander games still require players to track a second loss condition outside the app. Keeping commander damage inside the same tile avoids paper tracking and keeps all table-state interactions in one place.
+The life counter now supports shared-screen MTG play, but Commander games still require players to track a second loss condition outside the app. Keeping commander damage inside the same tile avoids paper tracking, while using a modal editor avoids overloading the base board with dense micro-controls.
 
 This is a natural follow-up to the original life-counter RFC, which explicitly left commander damage out of v1.
 
@@ -39,7 +39,7 @@ This is an extension of the existing MTG life fragment, not a separate top-level
 
 ### Visibility
 
-Add a `Commander Damage` toggle to the setup state, defaulting to `on`. When enabled, the play board shows commander-damage controls in every tile. When disabled, the board keeps the current life-only layout.
+Add a `Commander Damage` toggle to the setup state, defaulting to `on`. When enabled, the play board shows a commander-damage summary strip in every tile. When disabled, the board keeps the current life-only layout.
 
 Why:
 
@@ -49,7 +49,7 @@ Why:
 
 ### Tile Placement
 
-Commander damage belongs inside `LifePlayerUiModel` as bottom-of-tile content, below the large life total and below the primary `+` and `-` life interactions. It should not float outside the player cell and should not require opening a separate screen.
+Commander damage belongs inside `LifePlayerUiModel` as bottom-of-tile summary content, below the large life total and below the primary `+` and `-` life interactions. The tile should open a modal editor for changes rather than making the base grid itself directly editable.
 
 ## UX Proposal
 
@@ -81,7 +81,7 @@ Each commander-damage cell represents:
 To keep the layout stable, render one cell per seat, including self:
 
 - self cell: disabled, labeled `me`
-- opponent cells: interactive, numeric, starting at `0`
+- opponent cells: non-editable summary values, starting at `0`
 
 This mirrors the provided reference while avoiding gaps in the grid.
 
@@ -89,18 +89,33 @@ This mirrors the provided reference while avoiding gaps in the grid.
 
 Life interactions stay exactly as they are today.
 
-Commander-damage interactions should be compact:
+Commander-damage interactions should be modal:
 
-- tap a commander-damage cell to increment that source's damage by `1`
-- long-press a commander-damage cell to decrement by `1`, with a floor of `0`
-- self cells do nothing
+- tapping the commander-damage strip opens a dialog or modal bottom sheet for that defender
+- the base grid on the tile is a summary only and does not directly modify values
+- the modal shows one editable row per source seat, including a disabled `me` row
+- each opponent row has explicit increment and decrement controls
+- decrement floors at `0`
 - reaching `21` does not lock the value; users can decrement back to `20` or lower to correct mistakes
+- dismissing the modal returns to the main board with updated summary values
 
 Why this interaction:
 
-- it fits the limited bottom-of-tile space
-- it avoids adding separate `+` and `-` chrome for every opponent
-- it keeps the primary life controls visually dominant
+- it preserves the clean board-level layout
+- it reduces accidental edits from stray taps on a crowded shared screen
+- it gives the editor enough room for explicit `+` and `-` controls without shrinking the life UI
+
+### Modal Editor
+
+Recommended editor behavior:
+
+- title: `Commander Damage`
+- subtitle or supporting text identifies the defending player, for example `Damage dealt to Player 2`
+- one row per source seat in stable seat order
+- each row shows source identity, current value, decrement, and increment
+- the self row stays visible but disabled so seat mapping remains consistent
+- values update immediately in the shared ViewModel as the user edits
+- modal dismissal uses normal back, outside-tap, or close affordances; no extra save step is required in v1
 
 ### Visual Treatment
 
@@ -109,6 +124,7 @@ Why this interaction:
 - Opponent cells should use the source player's seat color family so the source mapping is consistent across the board.
 - The self cell should use a neutral outlined or muted treatment rather than a player color.
 - At `21` or more, the relevant commander-damage cell should switch to an error or warning treatment.
+- The base-strip summary should look tappable as a whole, but the individual cells should not look like standalone buttons.
 
 ## Layout Strategy
 
@@ -187,6 +203,15 @@ Recommended shape:
 
 This keeps the fragment focused on rendering and click wiring, matching the existing architecture where seat colors and rotations are already derived in `MtgLifeViewModel`.
 
+Recommended additional UI state:
+
+- `CommanderDamageEditorUiModel`
+  - `defenderSeatIndex`
+  - `defenderLabel`
+  - `List<CommanderDamageUiModel> commanderDamages`
+
+This can be exposed either as part of the main screen state or as transient dialog state, depending on whether the implementation uses a `DialogFragment` or an in-fragment modal surface.
+
 ### Fragment Responsibilities
 
 `MtgLifeFragment` should:
@@ -195,7 +220,9 @@ This keeps the fragment focused on rendering and click wiring, matching the exis
 - bind the existing life buttons and life total exactly as today
 - show or hide the commander-damage container per player
 - inflate or bind commander-damage cells from `LifePlayerUiModel`
-- route tap and long-press events to `MtgLifeViewModel`
+- open the commander-damage editor when a player tile summary strip is tapped
+- route modal increment and decrement events to `MtgLifeViewModel`
+- restore the modal cleanly across configuration changes if it is open
 
 ### ViewModel Responsibilities
 
@@ -204,15 +231,17 @@ This keeps the fragment focused on rendering and click wiring, matching the exis
 - validate the new setup toggle input
 - create the commander-damage matrix on game start when enabled
 - expose commander-damage UI state inside each `LifePlayerUiModel`
+- expose the currently edited defender, if the implementation stores editor state in the ViewModel
 - increment and decrement commander damage for a specific defender/source pair
 - clamp commander damage at `0`
 - derive `lethal` once a source reaches `21` or more
 
 ## Accessibility and Usability
 
-- Every commander-damage cell needs a content description in the form `Commander damage from player 3 to player 1: 7`.
+- The summary strip needs a content description in the form `Commander damage for player 1. Double tap to edit.`
+- Each summary value should still expose source-aware spoken text such as `Commander damage from player 3 to player 1: 7`.
 - The self cell should expose a description such as `Your own commander damage slot`.
-- Long-press decrement must have an accessibility fallback. Recommended approach: include a custom accessibility action for decrement on interactive commander-damage cells.
+- The modal editor must provide accessible increment and decrement controls without relying on long-press.
 - Do not rely on color alone to identify source seats; the order must remain stable and the content description must include player numbers.
 - The commander strip must not reduce life-button touch targets below 48dp.
 
@@ -223,7 +252,7 @@ Add or update local JVM and Robolectric coverage for:
 - `MtgLifeViewModelTest`
   - new games initialize a zeroed commander-damage matrix when enabled
   - disabling commander damage leaves player life state unchanged and hides commander UI
-  - tapping a source increments only the targeted defender/source entry
+  - incrementing from the modal updates only the targeted defender/source entry
   - decrement never goes below `0`
   - self entries remain `0`
   - `21` commander damage marks the entry as lethal
@@ -232,8 +261,10 @@ Add or update local JVM and Robolectric coverage for:
 - `MtgLifeFragmentTest`
   - setup shows the commander-damage toggle with default `on`
   - starting a commander-enabled game shows the bottom commander strip
-  - interactive commander cells increment on tap
-  - self cells are disabled
+  - tapping a commander summary strip opens the modal editor for that defender
+  - modal increment and decrement controls update the visible summary values
+  - self rows are disabled in the modal
+  - dismissing and reopening the modal shows the current values
   - commander-disabled games do not render the strip
 
 ## Implementation Plan
@@ -242,16 +273,17 @@ Add or update local JVM and Robolectric coverage for:
 2. Add commander-damage saved-state keys and matrix logic to `MtgLifeViewModel`.
 3. Extend `LifePlayerUiModel` with commander-damage child state.
 4. Update `life_player_cell.xml` to reserve bottom space for the commander strip.
-5. Bind commander-damage cells in `MtgLifeFragment`, including tap and long-press handlers.
-6. Add lethal-state styling and accessibility actions.
-7. Add focused ViewModel and fragment tests.
+5. Add a commander-damage dialog or modal surface and its row layout.
+6. Bind the tile summary strip in `MtgLifeFragment` and wire modal increment and decrement handlers.
+7. Add lethal-state styling and accessibility actions.
+8. Add focused ViewModel and fragment tests.
 
 ## Risks and Mitigations
 
 - The bottom strip could crowd small 5- and 6-player layouts.
   - Mitigation: keep the commander UI compact, reserve a fixed bottom band, and auto-size the life total more aggressively when commander damage is enabled.
-- Long-press decrement is discoverable but not obvious.
-  - Mitigation: add a tooltip or helper text in the RFC implementation review if testing shows confusion, and always expose an accessibility decrement action.
+- The extra modal step could slow common edits.
+  - Mitigation: keep the summary strip easy to hit, open the editor with a single tap, and make modal controls explicit and fast.
 - Matrix indexing bugs are easy to introduce.
   - Mitigation: keep defender/source semantics explicit in method names and cover them with focused unit tests.
 


### PR DESCRIPTION
## Summary
- Add commander-damage state to the MTG life feature with a new `CommanderDamageUiModel` and per-player commander damage lists.
- Extend the setup flow with a `Commander Damage` toggle and persist the enabled state through `MtgLifeViewModel`.
- Render commander damage at the bottom of each player tile with tap-to-increment, long-press-to-decrement, self-slot handling, and lethal-state styling.
- Update the life tile layout and strings to support the new commander-damage strip.

## Testing
- Added `MtgLifeViewModelTest` coverage for commander-damage initialization, increment/decrement behavior, visibility, and lethal-state handling.
- Updated fragment and setup behavior to support the new toggle and bottom-of-tile commander-damage UI.
- Not run (not requested).