### PR TITLE
Add half-tile life controls with long-press +/-10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 28
-        versionName "1.8.1"
+        versionCode 29
+        versionName "1.8.2"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -9,6 +9,7 @@ public class LifePlayerUiModel {
     private final int backgroundColorRes;
     private final int foregroundColorRes;
     private final int recentLifeChange;
+    private final long recentLifeChangeTimestampMs;
     private final boolean commanderDamageVisible;
     private final List<CommanderDamageUiModel> commanderDamages;
 
@@ -19,6 +20,7 @@ public class LifePlayerUiModel {
             int backgroundColorRes,
             int foregroundColorRes,
             int recentLifeChange,
+            long recentLifeChangeTimestampMs,
             boolean commanderDamageVisible,
             List<CommanderDamageUiModel> commanderDamages) {
         this.seatIndex = seatIndex;
@@ -27,6 +29,7 @@ public class LifePlayerUiModel {
         this.backgroundColorRes = backgroundColorRes;
         this.foregroundColorRes = foregroundColorRes;
         this.recentLifeChange = recentLifeChange;
+        this.recentLifeChangeTimestampMs = recentLifeChangeTimestampMs;
         this.commanderDamageVisible = commanderDamageVisible;
         this.commanderDamages = commanderDamages;
     }
@@ -53,6 +56,10 @@ public class LifePlayerUiModel {
 
     public int getRecentLifeChange() {
         return recentLifeChange;
+    }
+
+    public long getRecentLifeChangeTimestampMs() {
+        return recentLifeChangeTimestampMs;
     }
 
     public boolean isCommanderDamageVisible() {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -8,6 +8,7 @@ public class LifePlayerUiModel {
     private final int rotationDegrees;
     private final int backgroundColorRes;
     private final int foregroundColorRes;
+    private final int recentLifeChange;
     private final boolean commanderDamageVisible;
     private final List<CommanderDamageUiModel> commanderDamages;
 
@@ -17,6 +18,7 @@ public class LifePlayerUiModel {
             int rotationDegrees,
             int backgroundColorRes,
             int foregroundColorRes,
+            int recentLifeChange,
             boolean commanderDamageVisible,
             List<CommanderDamageUiModel> commanderDamages) {
         this.seatIndex = seatIndex;
@@ -24,6 +26,7 @@ public class LifePlayerUiModel {
         this.rotationDegrees = rotationDegrees;
         this.backgroundColorRes = backgroundColorRes;
         this.foregroundColorRes = foregroundColorRes;
+        this.recentLifeChange = recentLifeChange;
         this.commanderDamageVisible = commanderDamageVisible;
         this.commanderDamages = commanderDamages;
     }
@@ -46,6 +49,10 @@ public class LifePlayerUiModel {
 
     public int getForegroundColorRes() {
         return foregroundColorRes;
+    }
+
+    public int getRecentLifeChange() {
+        return recentLifeChange;
     }
 
     public boolean isCommanderDamageVisible() {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -266,6 +266,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.tvLifeCount.setContentDescription(String.valueOf(player.getLifeTotal()));
         cellBinding.tvLifeCount.setTextColor(foregroundColor);
         cellBinding.playerCellContainer.setBackgroundColor(backgroundColor);
+        bindRecentLifeChange(cellBinding, player.getRecentLifeChange(), foregroundColor);
 
         cellBinding.btnMinus.setIconTint(ColorStateList.valueOf(foregroundColor));
         cellBinding.btnPlus.setIconTint(ColorStateList.valueOf(foregroundColor));
@@ -368,6 +369,23 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         damage.getAmount()));
 
         return summaryCell;
+    }
+
+    private void bindRecentLifeChange(
+            LifePlayerCellBinding cellBinding, int recentLifeChange, int foregroundColor) {
+        if (recentLifeChange == 0) {
+            cellBinding.tvRecentLifeChange.setVisibility(View.GONE);
+            cellBinding.tvRecentLifeChange.setText(null);
+            cellBinding.tvRecentLifeChange.setContentDescription(null);
+            return;
+        }
+
+        String indicatorText =
+                recentLifeChange > 0 ? "+" + recentLifeChange : String.valueOf(recentLifeChange);
+        cellBinding.tvRecentLifeChange.setVisibility(View.VISIBLE);
+        cellBinding.tvRecentLifeChange.setText(indicatorText);
+        cellBinding.tvRecentLifeChange.setTextColor(foregroundColor);
+        cellBinding.tvRecentLifeChange.setContentDescription(indicatorText);
     }
 
     private View createCommanderSummarySpacer() {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -290,13 +290,15 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.lifeDecrementZone.setOnLongClickListener(
                 v -> {
                     viewModel.decrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA);
-                    startLifeHoldRepeat(v, () -> viewModel.decrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA));
+                    startLifeHoldRepeat(
+                            v, () -> viewModel.decrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA));
                     return true;
                 });
         cellBinding.lifeIncrementZone.setOnLongClickListener(
                 v -> {
                     viewModel.incrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA);
-                    startLifeHoldRepeat(v, () -> viewModel.incrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA));
+                    startLifeHoldRepeat(
+                            v, () -> viewModel.incrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA));
                     return true;
                 });
         cellBinding.lifeDecrementZone.setOnTouchListener(this::handleLifeHoldTouch);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -8,6 +8,8 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import android.text.Editable;
 import android.util.TypedValue;
@@ -16,6 +18,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -49,6 +52,7 @@ import java.util.Map;
 public class MtgLifeFragment extends Fragment implements MenuProvider {
     private static final int PREVIEW_PLAYER_COUNT = 4;
     private static final int LIFE_LONG_PRESS_DELTA = 10;
+    private static final long LIFE_HOLD_REPEAT_INTERVAL_MS = 1000L;
 
     private LifeFragmentBinding binding;
     private MtgLifeViewModel viewModel;
@@ -56,6 +60,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     private int currentBoardPlayerCount = -1;
     private Integer activeDialogDefenderSeatIndex = null;
     private final Map<Integer, TextView> activeDialogDamageTextViews = new HashMap<>();
+    private final Handler holdRepeatHandler = new Handler(Looper.getMainLooper());
+    private final Map<View, Runnable> activeLifeHoldRunnables = new HashMap<>();
 
     @Nullable @Override
     public View onCreateView(
@@ -284,13 +290,17 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.lifeDecrementZone.setOnLongClickListener(
                 v -> {
                     viewModel.decrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA);
+                    startLifeHoldRepeat(v, () -> viewModel.decrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA));
                     return true;
                 });
         cellBinding.lifeIncrementZone.setOnLongClickListener(
                 v -> {
                     viewModel.incrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA);
+                    startLifeHoldRepeat(v, () -> viewModel.incrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA));
                     return true;
                 });
+        cellBinding.lifeDecrementZone.setOnTouchListener(this::handleLifeHoldTouch);
+        cellBinding.lifeIncrementZone.setOnTouchListener(this::handleLifeHoldTouch);
 
         bindCommanderDamageSummary(cellBinding, player, playerCount);
 
@@ -706,6 +716,45 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         return (int) (dp * getResources().getDisplayMetrics().density);
     }
 
+    private void startLifeHoldRepeat(View view, Runnable action) {
+        stopLifeHoldRepeat(view);
+
+        Runnable repeatRunnable =
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        Runnable activeRunnable = activeLifeHoldRunnables.get(view);
+                        if (activeRunnable != this || !view.isPressed()) {
+                            stopLifeHoldRepeat(view);
+                            return;
+                        }
+
+                        action.run();
+                        holdRepeatHandler.postDelayed(this, LIFE_HOLD_REPEAT_INTERVAL_MS);
+                    }
+                };
+
+        activeLifeHoldRunnables.put(view, repeatRunnable);
+        holdRepeatHandler.postDelayed(repeatRunnable, LIFE_HOLD_REPEAT_INTERVAL_MS);
+    }
+
+    private boolean handleLifeHoldTouch(View view, MotionEvent event) {
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_UP
+                || action == MotionEvent.ACTION_CANCEL
+                || action == MotionEvent.ACTION_OUTSIDE) {
+            stopLifeHoldRepeat(view);
+        }
+        return false;
+    }
+
+    private void stopLifeHoldRepeat(View view) {
+        Runnable repeatRunnable = activeLifeHoldRunnables.remove(view);
+        if (repeatRunnable != null) {
+            holdRepeatHandler.removeCallbacks(repeatRunnable);
+        }
+    }
+
     private int getSourceSeatForGridSlot(int slotIndex, int defenderSeatIndex, int totalPlayers) {
         int[] mapping =
                 switch (totalPlayers) {
@@ -743,6 +792,10 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        for (Runnable repeatRunnable : activeLifeHoldRunnables.values()) {
+            holdRepeatHandler.removeCallbacks(repeatRunnable);
+        }
+        activeLifeHoldRunnables.clear();
         binding = null;
         inputsInitialized = false;
         currentBoardPlayerCount = -1;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.text.Editable;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -266,7 +267,11 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.tvLifeCount.setContentDescription(String.valueOf(player.getLifeTotal()));
         cellBinding.tvLifeCount.setTextColor(foregroundColor);
         cellBinding.playerCellContainer.setBackgroundColor(backgroundColor);
-        bindRecentLifeChange(cellBinding, player.getRecentLifeChange(), foregroundColor);
+        bindRecentLifeChange(
+                cellBinding,
+                player.getRecentLifeChange(),
+                player.getRecentLifeChangeTimestampMs(),
+                foregroundColor);
 
         cellBinding.btnMinus.setIconTint(ColorStateList.valueOf(foregroundColor));
         cellBinding.btnPlus.setIconTint(ColorStateList.valueOf(foregroundColor));
@@ -372,11 +377,18 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     }
 
     private void bindRecentLifeChange(
-            LifePlayerCellBinding cellBinding, int recentLifeChange, int foregroundColor) {
-        if (recentLifeChange == 0) {
+            LifePlayerCellBinding cellBinding,
+            int recentLifeChange,
+            long recentLifeChangeTimestampMs,
+            int foregroundColor) {
+        long ageMs = SystemClock.elapsedRealtime() - recentLifeChangeTimestampMs;
+        if (recentLifeChange == 0
+                || recentLifeChangeTimestampMs <= 0
+                || ageMs >= MtgLifeViewModel.RECENT_LIFE_CHANGE_WINDOW_MS) {
             cellBinding.tvRecentLifeChange.setVisibility(View.GONE);
             cellBinding.tvRecentLifeChange.setText(null);
             cellBinding.tvRecentLifeChange.setContentDescription(null);
+            cellBinding.tvRecentLifeChange.setTag(null);
             return;
         }
 
@@ -386,6 +398,17 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.tvRecentLifeChange.setText(indicatorText);
         cellBinding.tvRecentLifeChange.setTextColor(foregroundColor);
         cellBinding.tvRecentLifeChange.setContentDescription(indicatorText);
+        cellBinding.tvRecentLifeChange.setTag(recentLifeChangeTimestampMs);
+
+        long remainingMs = MtgLifeViewModel.RECENT_LIFE_CHANGE_WINDOW_MS - ageMs;
+        cellBinding.tvRecentLifeChange.postDelayed(
+                () -> {
+                    Object tag = cellBinding.tvRecentLifeChange.getTag();
+                    if (tag instanceof Long timestamp && timestamp == recentLifeChangeTimestampMs) {
+                        cellBinding.tvRecentLifeChange.setVisibility(View.GONE);
+                    }
+                },
+                remainingMs);
     }
 
     private View createCommanderSummarySpacer() {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -47,6 +47,7 @@ import java.util.Map;
 
 public class MtgLifeFragment extends Fragment implements MenuProvider {
     private static final int PREVIEW_PLAYER_COUNT = 4;
+    private static final int LIFE_LONG_PRESS_DELTA = 10;
 
     private LifeFragmentBinding binding;
     private MtgLifeViewModel viewModel;
@@ -268,12 +269,22 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
         cellBinding.btnMinus.setIconTint(ColorStateList.valueOf(foregroundColor));
         cellBinding.btnPlus.setIconTint(ColorStateList.valueOf(foregroundColor));
-        cellBinding.btnMinus.setContentDescription(
+        cellBinding.lifeDecrementZone.setContentDescription(
                 getString(R.string.mtg_btn_minus_desc, seatIndex + 1));
-        cellBinding.btnPlus.setContentDescription(
+        cellBinding.lifeIncrementZone.setContentDescription(
                 getString(R.string.mtg_btn_plus_desc, seatIndex + 1));
-        cellBinding.btnMinus.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
-        cellBinding.btnPlus.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+        cellBinding.lifeDecrementZone.setOnClickListener(v -> viewModel.decrementLife(seatIndex));
+        cellBinding.lifeIncrementZone.setOnClickListener(v -> viewModel.incrementLife(seatIndex));
+        cellBinding.lifeDecrementZone.setOnLongClickListener(
+                v -> {
+                    viewModel.decrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA);
+                    return true;
+                });
+        cellBinding.lifeIncrementZone.setOnLongClickListener(
+                v -> {
+                    viewModel.incrementLifeBy(seatIndex, LIFE_LONG_PRESS_DELTA);
+                    return true;
+                });
 
         bindCommanderDamageSummary(cellBinding, player, playerCount);
 

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -13,6 +13,7 @@ public class MtgLifeViewModel extends ViewModel {
     private static final String KEY_PLAYER_COUNT = "playerCount";
     private static final String KEY_STARTING_LIFE = "startingLife";
     private static final String KEY_CURRENT_LIVES = "currentLives";
+    private static final String KEY_RECENT_LIFE_CHANGES = "recentLifeChanges";
     private static final String KEY_PLAYERS_ERROR_RES_ID = "playersErrorResId";
     private static final String KEY_LIFE_ERROR_RES_ID = "lifeErrorResId";
     private static final String KEY_COMMANDER_DAMAGE_ENABLED = "commanderDamageEnabled";
@@ -66,6 +67,7 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_STARTING_LIFE, parsedStartingLife);
         savedStateHandle.set(
                 KEY_CURRENT_LIVES, createInitialLives(parsedPlayerCount, parsedStartingLife));
+        savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, createInitialRecentLifeChanges(parsedPlayerCount));
         savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, commanderDamageEnabled);
         savedStateHandle.set(
                 KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(parsedPlayerCount));
@@ -122,6 +124,7 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_PLAYER_COUNT, DEFAULT_PLAYER_COUNT);
         savedStateHandle.set(KEY_STARTING_LIFE, DEFAULT_STARTING_LIFE);
         savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
+        savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, new ArrayList<Integer>());
         savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
         savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
         savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, true);
@@ -166,6 +169,14 @@ public class MtgLifeViewModel extends ViewModel {
         return matrix;
     }
 
+    private ArrayList<Integer> createInitialRecentLifeChanges(int playerCount) {
+        ArrayList<Integer> recentChanges = new ArrayList<>();
+        for (int i = 0; i < playerCount; i++) {
+            recentChanges.add(0);
+        }
+        return recentChanges;
+    }
+
     private void updateLifeTotal(int seatIndex, int delta) {
         List<Integer> currentLives = getCurrentLives();
         if (!isValidSeatIndex(currentLives, seatIndex)) {
@@ -175,6 +186,7 @@ public class MtgLifeViewModel extends ViewModel {
         ArrayList<Integer> updatedLives = new ArrayList<>(currentLives);
         updatedLives.set(seatIndex, updatedLives.get(seatIndex) + delta);
         savedStateHandle.set(KEY_CURRENT_LIVES, updatedLives);
+        updateRecentLifeChange(seatIndex, delta);
         updateUiState();
     }
 
@@ -213,6 +225,18 @@ public class MtgLifeViewModel extends ViewModel {
         ArrayList<Integer> updatedLives = new ArrayList<>(currentLives);
         updatedLives.set(defenderSeatIndex, updatedLives.get(defenderSeatIndex) + delta);
         savedStateHandle.set(KEY_CURRENT_LIVES, updatedLives);
+        updateRecentLifeChange(defenderSeatIndex, delta);
+    }
+
+    private void updateRecentLifeChange(int seatIndex, int delta) {
+        List<Integer> recentLifeChanges = getRecentLifeChanges();
+        if (!isValidSeatIndex(recentLifeChanges, seatIndex)) {
+            return;
+        }
+
+        ArrayList<Integer> updatedRecentLifeChanges = new ArrayList<>(recentLifeChanges);
+        updatedRecentLifeChanges.set(seatIndex, delta);
+        savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, updatedRecentLifeChanges);
     }
 
     private boolean isShowingSetup() {
@@ -240,6 +264,10 @@ public class MtgLifeViewModel extends ViewModel {
 
     private ArrayList<ArrayList<Integer>> getCommanderDamageMatrix() {
         return savedStateHandle.get(KEY_COMMANDER_DAMAGE_MATRIX);
+    }
+
+    private List<Integer> getRecentLifeChanges() {
+        return savedStateHandle.get(KEY_RECENT_LIFE_CHANGES);
     }
 
     private boolean isValidSeatIndex(List<?> list, int seatIndex) {
@@ -338,11 +366,16 @@ public class MtgLifeViewModel extends ViewModel {
         Integer lifeErrorResId = savedStateHandle.get(KEY_LIFE_ERROR_RES_ID);
         boolean commanderDamageEnabled = getCommanderDamageEnabled();
         ArrayList<ArrayList<Integer>> commanderDamageMatrix = getCommanderDamageMatrix();
+        List<Integer> recentLifeChanges = getRecentLifeChanges();
 
         List<LifePlayerUiModel> players = new ArrayList<>();
         if (!showingSetup && currentLives != null) {
             int totalPlayers = currentLives.size();
             for (int seatIndex = 0; seatIndex < totalPlayers; seatIndex++) {
+                int recentLifeChange =
+                        recentLifeChanges != null && seatIndex < recentLifeChanges.size()
+                                ? recentLifeChanges.get(seatIndex)
+                                : 0;
                 players.add(
                         new LifePlayerUiModel(
                                 seatIndex,
@@ -350,6 +383,7 @@ public class MtgLifeViewModel extends ViewModel {
                                 getRotationForSeat(seatIndex, totalPlayers),
                                 getBackgroundColorResForSeat(seatIndex),
                                 getForegroundColorResForSeat(seatIndex),
+                                recentLifeChange,
                                 commanderDamageEnabled && totalPlayers > 1,
                                 buildCommanderDamages(
                                         seatIndex, commanderDamageMatrix, totalPlayers)));

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -1,5 +1,6 @@
 package com.nicue.onetwo.ui.life;
 
+import android.os.SystemClock;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.SavedStateHandle;
@@ -14,6 +15,7 @@ public class MtgLifeViewModel extends ViewModel {
     private static final String KEY_STARTING_LIFE = "startingLife";
     private static final String KEY_CURRENT_LIVES = "currentLives";
     private static final String KEY_RECENT_LIFE_CHANGES = "recentLifeChanges";
+    private static final String KEY_RECENT_LIFE_CHANGE_TIMESTAMPS = "recentLifeChangeTimestamps";
     private static final String KEY_PLAYERS_ERROR_RES_ID = "playersErrorResId";
     private static final String KEY_LIFE_ERROR_RES_ID = "lifeErrorResId";
     private static final String KEY_COMMANDER_DAMAGE_ENABLED = "commanderDamageEnabled";
@@ -24,12 +26,23 @@ public class MtgLifeViewModel extends ViewModel {
     private static final int MIN_PLAYER_COUNT = 1;
     private static final int MAX_PLAYER_COUNT = 6;
     private static final int COMMANDER_LETHAL_DAMAGE = 21;
+    public static final long RECENT_LIFE_CHANGE_WINDOW_MS = 2000L;
 
     private final SavedStateHandle savedStateHandle;
     private final MutableLiveData<MtgLifeUiState> uiState = new MutableLiveData<>();
+    private final NowProvider nowProvider;
+
+    interface NowProvider {
+        long now();
+    }
 
     public MtgLifeViewModel(SavedStateHandle savedStateHandle) {
+        this(savedStateHandle, SystemClock::elapsedRealtime);
+    }
+
+    MtgLifeViewModel(SavedStateHandle savedStateHandle, NowProvider nowProvider) {
         this.savedStateHandle = savedStateHandle;
+        this.nowProvider = nowProvider;
 
         if (!savedStateHandle.contains(KEY_SHOWING_SETUP)) {
             initializeDefaultState();
@@ -68,6 +81,9 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(
                 KEY_CURRENT_LIVES, createInitialLives(parsedPlayerCount, parsedStartingLife));
         savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, createInitialRecentLifeChanges(parsedPlayerCount));
+        savedStateHandle.set(
+                KEY_RECENT_LIFE_CHANGE_TIMESTAMPS,
+                createInitialRecentLifeChangeTimestamps(parsedPlayerCount));
         savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, commanderDamageEnabled);
         savedStateHandle.set(
                 KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(parsedPlayerCount));
@@ -125,6 +141,7 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_STARTING_LIFE, DEFAULT_STARTING_LIFE);
         savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
         savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, new ArrayList<Integer>());
+        savedStateHandle.set(KEY_RECENT_LIFE_CHANGE_TIMESTAMPS, new ArrayList<Long>());
         savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
         savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
         savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, true);
@@ -175,6 +192,14 @@ public class MtgLifeViewModel extends ViewModel {
             recentChanges.add(0);
         }
         return recentChanges;
+    }
+
+    private ArrayList<Long> createInitialRecentLifeChangeTimestamps(int playerCount) {
+        ArrayList<Long> timestamps = new ArrayList<>();
+        for (int i = 0; i < playerCount; i++) {
+            timestamps.add(0L);
+        }
+        return timestamps;
     }
 
     private void updateLifeTotal(int seatIndex, int delta) {
@@ -230,13 +255,28 @@ public class MtgLifeViewModel extends ViewModel {
 
     private void updateRecentLifeChange(int seatIndex, int delta) {
         List<Integer> recentLifeChanges = getRecentLifeChanges();
-        if (!isValidSeatIndex(recentLifeChanges, seatIndex)) {
+        List<Long> recentLifeChangeTimestamps = getRecentLifeChangeTimestamps();
+        if (!isValidSeatIndex(recentLifeChanges, seatIndex)
+                || !isValidSeatIndex(recentLifeChangeTimestamps, seatIndex)) {
             return;
         }
 
+        long nowMs = nowProvider.now();
+        int previousChange = recentLifeChanges.get(seatIndex);
+        long previousTimestamp = recentLifeChangeTimestamps.get(seatIndex);
+        boolean withinAggregationWindow =
+                previousTimestamp > 0
+                        && nowMs - previousTimestamp <= RECENT_LIFE_CHANGE_WINDOW_MS;
+
         ArrayList<Integer> updatedRecentLifeChanges = new ArrayList<>(recentLifeChanges);
-        updatedRecentLifeChanges.set(seatIndex, delta);
+        updatedRecentLifeChanges.set(
+                seatIndex, withinAggregationWindow ? previousChange + delta : delta);
         savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, updatedRecentLifeChanges);
+
+        ArrayList<Long> updatedRecentLifeChangeTimestamps =
+                new ArrayList<>(recentLifeChangeTimestamps);
+        updatedRecentLifeChangeTimestamps.set(seatIndex, nowMs);
+        savedStateHandle.set(KEY_RECENT_LIFE_CHANGE_TIMESTAMPS, updatedRecentLifeChangeTimestamps);
     }
 
     private boolean isShowingSetup() {
@@ -268,6 +308,10 @@ public class MtgLifeViewModel extends ViewModel {
 
     private List<Integer> getRecentLifeChanges() {
         return savedStateHandle.get(KEY_RECENT_LIFE_CHANGES);
+    }
+
+    private List<Long> getRecentLifeChangeTimestamps() {
+        return savedStateHandle.get(KEY_RECENT_LIFE_CHANGE_TIMESTAMPS);
     }
 
     private boolean isValidSeatIndex(List<?> list, int seatIndex) {
@@ -367,6 +411,7 @@ public class MtgLifeViewModel extends ViewModel {
         boolean commanderDamageEnabled = getCommanderDamageEnabled();
         ArrayList<ArrayList<Integer>> commanderDamageMatrix = getCommanderDamageMatrix();
         List<Integer> recentLifeChanges = getRecentLifeChanges();
+        List<Long> recentLifeChangeTimestamps = getRecentLifeChangeTimestamps();
 
         List<LifePlayerUiModel> players = new ArrayList<>();
         if (!showingSetup && currentLives != null) {
@@ -376,6 +421,11 @@ public class MtgLifeViewModel extends ViewModel {
                         recentLifeChanges != null && seatIndex < recentLifeChanges.size()
                                 ? recentLifeChanges.get(seatIndex)
                                 : 0;
+                long recentLifeChangeTimestampMs =
+                        recentLifeChangeTimestamps != null
+                                        && seatIndex < recentLifeChangeTimestamps.size()
+                                ? recentLifeChangeTimestamps.get(seatIndex)
+                                : 0L;
                 players.add(
                         new LifePlayerUiModel(
                                 seatIndex,
@@ -384,6 +434,7 @@ public class MtgLifeViewModel extends ViewModel {
                                 getBackgroundColorResForSeat(seatIndex),
                                 getForegroundColorResForSeat(seatIndex),
                                 recentLifeChange,
+                                recentLifeChangeTimestampMs,
                                 commanderDamageEnabled && totalPlayers > 1,
                                 buildCommanderDamages(
                                         seatIndex, commanderDamageMatrix, totalPlayers)));

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -80,7 +80,8 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_STARTING_LIFE, parsedStartingLife);
         savedStateHandle.set(
                 KEY_CURRENT_LIVES, createInitialLives(parsedPlayerCount, parsedStartingLife));
-        savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, createInitialRecentLifeChanges(parsedPlayerCount));
+        savedStateHandle.set(
+                KEY_RECENT_LIFE_CHANGES, createInitialRecentLifeChanges(parsedPlayerCount));
         savedStateHandle.set(
                 KEY_RECENT_LIFE_CHANGE_TIMESTAMPS,
                 createInitialRecentLifeChangeTimestamps(parsedPlayerCount));
@@ -265,8 +266,7 @@ public class MtgLifeViewModel extends ViewModel {
         int previousChange = recentLifeChanges.get(seatIndex);
         long previousTimestamp = recentLifeChangeTimestamps.get(seatIndex);
         boolean withinAggregationWindow =
-                previousTimestamp > 0
-                        && nowMs - previousTimestamp <= RECENT_LIFE_CHANGE_WINDOW_MS;
+                previousTimestamp > 0 && nowMs - previousTimestamp <= RECENT_LIFE_CHANGE_WINDOW_MS;
 
         ArrayList<Integer> updatedRecentLifeChanges = new ArrayList<>(recentLifeChanges);
         updatedRecentLifeChanges.set(

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -82,6 +82,14 @@ public class MtgLifeViewModel extends ViewModel {
         updateLifeTotal(seatIndex, -1);
     }
 
+    public void incrementLifeBy(int seatIndex, int amount) {
+        updateLifeTotal(seatIndex, amount);
+    }
+
+    public void decrementLifeBy(int seatIndex, int amount) {
+        updateLifeTotal(seatIndex, -amount);
+    }
+
     public void incrementCommanderDamage(int defenderSeatIndex, int sourceSeatIndex) {
         updateCommanderDamage(defenderSeatIndex, sourceSeatIndex, 1);
     }

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -45,6 +45,20 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_recent_life_change"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:visibility="gone"
+            app:layout_constraintEnd_toStartOf="@id/btn_plus"
+            app:layout_constraintStart_toEndOf="@id/btn_minus"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_life_count"
             android:layout_width="0dp"
             android:layout_height="0dp"
@@ -60,9 +74,9 @@
             app:autoSizeTextType="uniform"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
-            app:layout_constraintHeight_percent="0.6"
             app:layout_constraintStart_toEndOf="@id/btn_minus"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/tv_recent_life_change"
+            app:layout_constraintVertical_bias="0.4" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_plus"

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -16,12 +16,22 @@
         app:layout_constraintTop_toTopOf="parent"
         android:padding="@dimen/space_sm">
 
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/life_hit_zone_divider"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_minus"
             style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="56dp"
             android:layout_height="56dp"
             android:contentDescription="@string/mtg_btn_minus_default_desc"
+            android:clickable="false"
+            android:focusable="false"
+            android:importantForAccessibility="no"
             android:insetLeft="0dp"
             android:insetTop="0dp"
             android:insetRight="0dp"
@@ -60,6 +70,9 @@
             android:layout_width="56dp"
             android:layout_height="56dp"
             android:contentDescription="@string/mtg_btn_plus_default_desc"
+            android:clickable="false"
+            android:focusable="false"
+            android:importantForAccessibility="no"
             android:insetLeft="0dp"
             android:insetTop="0dp"
             android:insetRight="0dp"
@@ -72,13 +85,40 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <View
+            android:id="@+id/life_decrement_zone"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/life_hit_zone_divider"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/life_increment_zone"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/life_hit_zone_divider"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <LinearLayout
             android:id="@+id/commander_damage_grid"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:layout_marginTop="4dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:orientation="vertical"
             android:visibility="gone"
+            android:elevation="2dp"
             app:layout_constraintWidth_percent="0.6"
             app:layout_constraintWidth_max="140dp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -54,9 +54,10 @@
             android:textSize="20sp"
             android:textStyle="bold"
             android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/tv_life_count"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
             app:layout_constraintStart_toEndOf="@id/btn_minus"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintVertical_bias="1.0" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_life_count"
@@ -74,9 +75,9 @@
             app:autoSizeTextType="uniform"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
+            app:layout_constraintHeight_percent="0.6"
             app:layout_constraintStart_toEndOf="@id/btn_minus"
-            app:layout_constraintTop_toBottomOf="@id/tv_recent_life_change"
-            app:layout_constraintVertical_bias="0.4" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_plus"

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import android.app.Dialog;
 import android.os.Looper;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -13,6 +14,7 @@ import android.widget.TextView;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.fragment.app.testing.FragmentScenario;
 import com.nicue.onetwo.R;
+import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -475,6 +477,53 @@ public class MtgLifeFragmentTest {
                                                 R.string.mtg_commander_damage_increase_desc, 4, 5));
                         assertNotNull(incZone3);
                         assertNotNull(incZone4);
+                    });
+        }
+    }
+
+    @Test
+    public void testHoldingLifeZoneRepeatsTenPointChangeEveryOnePointFiveSeconds() {
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
+
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        assertNotNull(startButton);
+                        startButton.performClick();
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        View player1 = fragment.requireView().findViewById(R.id.player_1);
+                        assertNotNull(player1);
+
+                        View incrementZone = player1.findViewById(R.id.life_increment_zone);
+                        assertNotNull(incrementZone);
+
+                        incrementZone.setPressed(true);
+                        incrementZone.performLongClick();
+                        Shadows.shadowOf(Looper.getMainLooper())
+                                .idleFor(1500, TimeUnit.MILLISECONDS);
+                        incrementZone.setPressed(false);
+
+                        MotionEvent cancelEvent =
+                                MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_CANCEL, 0f, 0f, 0);
+                        incrementZone.dispatchTouchEvent(cancelEvent);
+                        cancelEvent.recycle();
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        View player1 = fragment.requireView().findViewById(R.id.player_1);
+                        assertNotNull(player1);
+
+                        TextView life1 = player1.findViewById(R.id.tv_life_count);
+                        TextView recentChange1 = player1.findViewById(R.id.tv_recent_life_change);
+                        assertEquals("60", life1.getText().toString());
+                        assertEquals("+20", recentChange1.getText().toString());
                     });
         }
     }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -98,8 +98,12 @@ public class MtgLifeFragmentTest {
                         // Verify starting life totals are 40
                         TextView life1 = player1.findViewById(R.id.tv_life_count);
                         TextView life2 = player2.findViewById(R.id.tv_life_count);
+                        TextView recentChange1 = player1.findViewById(R.id.tv_recent_life_change);
+                        TextView recentChange2 = player2.findViewById(R.id.tv_recent_life_change);
                         assertEquals("40", life1.getText().toString());
                         assertEquals("40", life2.getText().toString());
+                        assertEquals(View.GONE, recentChange1.getVisibility());
+                        assertEquals(View.GONE, recentChange2.getVisibility());
 
                         // Tap right half for player 1
                         View incrementZone1 = player1.findViewById(R.id.life_increment_zone);
@@ -124,9 +128,15 @@ public class MtgLifeFragmentTest {
                         assertNotNull(player2);
                         TextView life1 = player1.findViewById(R.id.tv_life_count);
                         TextView life2 = player2.findViewById(R.id.tv_life_count);
+                        TextView recentChange1 = player1.findViewById(R.id.tv_recent_life_change);
+                        TextView recentChange2 = player2.findViewById(R.id.tv_recent_life_change);
 
                         assertEquals("41", life1.getText().toString());
                         assertEquals("39", life2.getText().toString());
+                        assertEquals(View.VISIBLE, recentChange1.getVisibility());
+                        assertEquals("+1", recentChange1.getText().toString());
+                        assertEquals(View.VISIBLE, recentChange2.getVisibility());
+                        assertEquals("-1", recentChange2.getText().toString());
                     });
         }
     }
@@ -355,8 +365,12 @@ public class MtgLifeFragmentTest {
 
                         TextView life1 = player1.findViewById(R.id.tv_life_count);
                         TextView life2 = player2.findViewById(R.id.tv_life_count);
+                        TextView recentChange1 = player1.findViewById(R.id.tv_recent_life_change);
+                        TextView recentChange2 = player2.findViewById(R.id.tv_recent_life_change);
                         assertEquals("50", life1.getText().toString());
                         assertEquals("30", life2.getText().toString());
+                        assertEquals("+10", recentChange1.getText().toString());
+                        assertEquals("-10", recentChange2.getText().toString());
                     });
         }
     }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -101,15 +101,15 @@ public class MtgLifeFragmentTest {
                         assertEquals("40", life1.getText().toString());
                         assertEquals("40", life2.getText().toString());
 
-                        // Tap PLUS button for player 1
-                        View btnPlus1 = player1.findViewById(R.id.btn_plus);
-                        assertNotNull(btnPlus1);
-                        btnPlus1.performClick();
+                        // Tap right half for player 1
+                        View incrementZone1 = player1.findViewById(R.id.life_increment_zone);
+                        assertNotNull(incrementZone1);
+                        incrementZone1.performClick();
 
-                        // Tap MINUS button for player 2
-                        View btnMinus2 = player2.findViewById(R.id.btn_minus);
-                        assertNotNull(btnMinus2);
-                        btnMinus2.performClick();
+                        // Tap left half for player 2
+                        View decrementZone2 = player2.findViewById(R.id.life_decrement_zone);
+                        assertNotNull(decrementZone2);
+                        decrementZone2.performClick();
                     });
 
             // 3. Verify life totals are updated accordingly
@@ -310,6 +310,53 @@ public class MtgLifeFragmentTest {
                                         fragment.getString(
                                                 R.string.mtg_commander_damage_cell_desc, 2, 1, 1));
                         assertNotNull(updatedSummary);
+                    });
+        }
+    }
+
+    @Test
+    public void testLongPressLifeZonesAdjustByTen() {
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
+
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+                        Button startButton = view.findViewById(R.id.start_game_button);
+                        assertNotNull(startButton);
+                        startButton.performClick();
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.requireView();
+                        View player1 = view.findViewById(R.id.player_1);
+                        View player2 = view.findViewById(R.id.player_2);
+                        assertNotNull(player1);
+                        assertNotNull(player2);
+
+                        View incrementZone1 = player1.findViewById(R.id.life_increment_zone);
+                        View decrementZone2 = player2.findViewById(R.id.life_decrement_zone);
+                        assertNotNull(incrementZone1);
+                        assertNotNull(decrementZone2);
+
+                        incrementZone1.performLongClick();
+                        decrementZone2.performLongClick();
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.requireView();
+                        View player1 = view.findViewById(R.id.player_1);
+                        View player2 = view.findViewById(R.id.player_2);
+                        assertNotNull(player1);
+                        assertNotNull(player2);
+
+                        TextView life1 = player1.findViewById(R.id.tv_life_count);
+                        TextView life2 = player2.findViewById(R.id.tv_life_count);
+                        assertEquals("50", life1.getText().toString());
+                        assertEquals("30", life2.getText().toString());
                     });
         }
     }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -21,7 +21,7 @@ import org.robolectric.annotation.Config;
 @Config(sdk = 34)
 public class MtgLifeViewModelTest {
     private static final class FakeNowProvider implements MtgLifeViewModel.NowProvider {
-        private long nowMs;
+        private long nowMs = 1L;
 
         @Override
         public long now() {
@@ -191,8 +191,7 @@ public class MtgLifeViewModelTest {
     }
 
     @Test
-    public void testRecentLifeChangeAggregatesWithinWindowAndResetsAfterTimeout()
-            throws Exception {
+    public void testRecentLifeChangeAggregatesWithinWindowAndResetsAfterTimeout() throws Exception {
         viewModel.validateAndStartGame("2", "20");
 
         viewModel.decrementLife(0);
@@ -293,14 +292,14 @@ public class MtgLifeViewModelTest {
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
         assertEquals(40, state.getPlayers().getFirst().getLifeTotal());
-        assertEquals(1, state.getPlayers().getFirst().getRecentLifeChange());
+        assertEquals(0, state.getPlayers().getFirst().getRecentLifeChange());
 
         // Decrement below 0 floor should be ignored
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
         assertEquals(40, state.getPlayers().getFirst().getLifeTotal());
-        assertEquals(1, state.getPlayers().getFirst().getRecentLifeChange());
+        assertEquals(0, state.getPlayers().getFirst().getRecentLifeChange());
     }
 
     @Test

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -191,6 +191,26 @@ public class MtgLifeViewModelTest {
     }
 
     @Test
+    public void testRecentLifeChangeAggregatesWithinWindowAndResetsAfterTimeout()
+            throws Exception {
+        viewModel.validateAndStartGame("2", "20");
+
+        viewModel.decrementLife(0);
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(-1, state.getPlayers().get(0).getRecentLifeChange());
+
+        nowProvider.advanceBy(MtgLifeViewModel.RECENT_LIFE_CHANGE_WINDOW_MS - 1);
+        viewModel.decrementLife(0);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(-2, state.getPlayers().get(0).getRecentLifeChange());
+
+        nowProvider.advanceBy(MtgLifeViewModel.RECENT_LIFE_CHANGE_WINDOW_MS + 1);
+        viewModel.decrementLife(0);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(-1, state.getPlayers().get(0).getRecentLifeChange());
+    }
+
+    @Test
     public void testRotationsForVaryingPlayerCounts() throws Exception {
         // 3 Players
         viewModel.validateAndStartGame("3", "40");

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -55,8 +55,10 @@ public class MtgLifeViewModelTest {
         assertEquals(2, state.getPlayers().size());
         assertEquals(0, state.getPlayers().get(0).getSeatIndex());
         assertEquals(20, state.getPlayers().get(0).getLifeTotal());
+        assertEquals(0, state.getPlayers().get(0).getRecentLifeChange());
         assertEquals(1, state.getPlayers().get(1).getSeatIndex());
         assertEquals(20, state.getPlayers().get(1).getLifeTotal());
+        assertEquals(0, state.getPlayers().get(1).getRecentLifeChange());
     }
 
     @Test
@@ -149,12 +151,29 @@ public class MtgLifeViewModelTest {
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(21, state.getPlayers().get(0).getLifeTotal());
         assertEquals(20, state.getPlayers().get(1).getLifeTotal());
+        assertEquals(1, state.getPlayers().get(0).getRecentLifeChange());
 
         // Decrement player 1 life
         viewModel.decrementLife(1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(21, state.getPlayers().get(0).getLifeTotal());
         assertEquals(19, state.getPlayers().get(1).getLifeTotal());
+        assertEquals(-1, state.getPlayers().get(1).getRecentLifeChange());
+    }
+
+    @Test
+    public void testRecentLifeChangeTracksLongPressDelta() throws Exception {
+        viewModel.validateAndStartGame("2", "20");
+
+        viewModel.incrementLifeBy(0, 10);
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(30, state.getPlayers().get(0).getLifeTotal());
+        assertEquals(10, state.getPlayers().get(0).getRecentLifeChange());
+
+        viewModel.decrementLifeBy(1, 10);
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(10, state.getPlayers().get(1).getLifeTotal());
+        assertEquals(-10, state.getPlayers().get(1).getRecentLifeChange());
     }
 
     @Test
@@ -226,24 +245,28 @@ public class MtgLifeViewModelTest {
         assertEquals(1, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
         assertEquals(39, state.getPlayers().getFirst().getLifeTotal());
         assertEquals(40, state.getPlayers().get(1).getLifeTotal());
+        assertEquals(-1, state.getPlayers().getFirst().getRecentLifeChange());
 
         // Self damage changes should be ignored
         viewModel.incrementCommanderDamage(0, 0);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().getFirst().getAmount());
         assertEquals(39, state.getPlayers().getFirst().getLifeTotal());
+        assertEquals(-1, state.getPlayers().getFirst().getRecentLifeChange());
 
         // Decrement player 0 damage from source player 1
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
         assertEquals(40, state.getPlayers().getFirst().getLifeTotal());
+        assertEquals(1, state.getPlayers().getFirst().getRecentLifeChange());
 
         // Decrement below 0 floor should be ignored
         viewModel.decrementCommanderDamage(0, 1);
         state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertEquals(0, state.getPlayers().getFirst().getCommanderDamages().get(1).getAmount());
         assertEquals(40, state.getPlayers().getFirst().getLifeTotal());
+        assertEquals(1, state.getPlayers().getFirst().getRecentLifeChange());
     }
 
     @Test

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -20,14 +20,28 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
 public class MtgLifeViewModelTest {
+    private static final class FakeNowProvider implements MtgLifeViewModel.NowProvider {
+        private long nowMs;
+
+        @Override
+        public long now() {
+            return nowMs;
+        }
+
+        void advanceBy(long deltaMs) {
+            nowMs += deltaMs;
+        }
+    }
 
     @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     private MtgLifeViewModel viewModel;
+    private FakeNowProvider nowProvider;
 
     @Before
     public void setUp() {
-        viewModel = new MtgLifeViewModel(new SavedStateHandle());
+        nowProvider = new FakeNowProvider();
+        viewModel = new MtgLifeViewModel(new SavedStateHandle(), nowProvider);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace the life tile’s button taps with left/right half hit zones while keeping the visible `- {life} +` treatment.
- Add long-press behavior for life controls: left half decrements by 10, right half increments by 10.
- Update the life fragment and view model wiring so commander damage and life controls use the same interaction pattern.
- Add/adjust Robolectric coverage for tap and long-press life interactions.

## Testing
- `testDebugUnitTest` for `MtgLifeViewModelTest` and `MtgLifeFragmentTest` passed locally.
- Verified single-tap life updates still work and long-press changes life totals by 10.