### PR TITLE
Add chess clock increments to timer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 29
-        versionName "1.8.2"
+        versionCode 30
+        versionName "1.8.3"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/data/timer/TimerSnapshot.java
+++ b/app/src/main/java/com/nicue/onetwo/data/timer/TimerSnapshot.java
@@ -8,13 +8,15 @@ public class TimerSnapshot {
     private final int runningIndex;
     private final boolean paused;
     private final long configuredDurationMs;
+    private final long configuredIncrementMs;
 
     public TimerSnapshot(List<Long> remainingTimes, int runningIndex, boolean paused,
-                         long configuredDurationMs) {
+                         long configuredDurationMs, long configuredIncrementMs) {
         this.remainingTimes = new ArrayList<>(remainingTimes);
         this.runningIndex = runningIndex;
         this.paused = paused;
         this.configuredDurationMs = configuredDurationMs;
+        this.configuredIncrementMs = configuredIncrementMs;
     }
 
     public ArrayList<Long> getRemainingTimes() {
@@ -31,5 +33,9 @@ public class TimerSnapshot {
 
     public long getConfiguredDurationMs() {
         return configuredDurationMs;
+    }
+
+    public long getConfiguredIncrementMs() {
+        return configuredIncrementMs;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/data/timer/TimerSnapshot.java
+++ b/app/src/main/java/com/nicue/onetwo/data/timer/TimerSnapshot.java
@@ -10,8 +10,12 @@ public class TimerSnapshot {
     private final long configuredDurationMs;
     private final long configuredIncrementMs;
 
-    public TimerSnapshot(List<Long> remainingTimes, int runningIndex, boolean paused,
-                         long configuredDurationMs, long configuredIncrementMs) {
+    public TimerSnapshot(
+            List<Long> remainingTimes,
+            int runningIndex,
+            boolean paused,
+            long configuredDurationMs,
+            long configuredIncrementMs) {
         this.remainingTimes = new ArrayList<>(remainingTimes);
         this.runningIndex = runningIndex;
         this.paused = paused;

--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerFragment.java
@@ -186,10 +186,7 @@ public class TimerFragment extends Fragment implements MenuProvider {
         NumberPicker incrementMinutePicker = dialogBinding.incrementMinutePicker;
         NumberPicker incrementSecondPicker = dialogBinding.incrementSecondsPicker;
         configureDurationPicker(minutePicker, secondPicker, configuredDuration);
-        configureDurationPicker(
-                incrementMinutePicker,
-                incrementSecondPicker,
-                configuredIncrement);
+        configureDurationPicker(incrementMinutePicker, incrementSecondPicker, configuredIncrement);
 
         new AlertDialog.Builder(requireContext())
                 .setView(dialogBinding.getRoot())
@@ -213,8 +210,8 @@ public class TimerFragment extends Fragment implements MenuProvider {
                 .show();
     }
 
-    private void configureDurationPicker(NumberPicker minutePicker, NumberPicker secondPicker,
-                                         long durationMs) {
+    private void configureDurationPicker(
+            NumberPicker minutePicker, NumberPicker secondPicker, long durationMs) {
         minutePicker.setMinValue(0);
         minutePicker.setMaxValue(999);
         minutePicker.setValue((int) ((durationMs / 1000L) / 60L));

--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerFragment.java
@@ -178,16 +178,49 @@ public class TimerFragment extends Fragment implements MenuProvider {
     private void showEditDialog() {
         TimerUiState state = viewModel.getUiState().getValue();
         long configuredDuration = state == null ? 300000L : state.getConfiguredDurationMs();
+        long configuredIncrement = state == null ? 0L : state.getConfiguredIncrementMs();
         MinutesAlertDialogBinding dialogBinding =
                 MinutesAlertDialogBinding.inflate(getLayoutInflater());
         NumberPicker minutePicker = dialogBinding.minutePicker;
         NumberPicker secondPicker = dialogBinding.secondsPicker;
+        NumberPicker incrementMinutePicker = dialogBinding.incrementMinutePicker;
+        NumberPicker incrementSecondPicker = dialogBinding.incrementSecondsPicker;
+        configureDurationPicker(minutePicker, secondPicker, configuredDuration);
+        configureDurationPicker(
+                incrementMinutePicker,
+                incrementSecondPicker,
+                configuredIncrement);
+
+        new AlertDialog.Builder(requireContext())
+                .setView(dialogBinding.getRoot())
+                .setTitle(R.string.timer_settings_title)
+                .setPositiveButton(
+                        android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                long durationMs =
+                                        (minutePicker.getValue() * 60L + secondPicker.getValue())
+                                                * 1000L;
+                                long incrementMs =
+                                        (incrementMinutePicker.getValue() * 60L
+                                                        + incrementSecondPicker.getValue())
+                                                * 1000L;
+                                viewModel.editDuration(durationMs, incrementMs);
+                            }
+                        })
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    private void configureDurationPicker(NumberPicker minutePicker, NumberPicker secondPicker,
+                                         long durationMs) {
         minutePicker.setMinValue(0);
         minutePicker.setMaxValue(999);
-        minutePicker.setValue((int) ((configuredDuration / 1000L) / 60L));
+        minutePicker.setValue((int) ((durationMs / 1000L) / 60L));
         secondPicker.setMinValue(0);
         secondPicker.setMaxValue(59);
-        secondPicker.setValue((int) ((configuredDuration / 1000L) % 60L));
+        secondPicker.setValue((int) ((durationMs / 1000L) % 60L));
         secondPicker.setFormatter(
                 new NumberPicker.Formatter() {
                     @Override
@@ -195,23 +228,6 @@ public class TimerFragment extends Fragment implements MenuProvider {
                         return String.format(java.util.Locale.getDefault(), "%02d", value);
                     }
                 });
-
-        new AlertDialog.Builder(requireContext())
-                .setView(dialogBinding.getRoot())
-                .setTitle("Set Time:")
-                .setPositiveButton(
-                        "Set",
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                long durationMs =
-                                        (minutePicker.getValue() * 60L + secondPicker.getValue())
-                                                * 1000L;
-                                viewModel.editDuration(durationMs);
-                            }
-                        })
-                .setNegativeButton("Cancel", null)
-                .show();
     }
 
     private int resolveButtonColor(TimerItemUiModel timer) {

--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerUiState.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerUiState.java
@@ -9,8 +9,11 @@ public class TimerUiState {
     private final long configuredDurationMs;
     private final long configuredIncrementMs;
 
-    public TimerUiState(List<TimerItemUiModel> timers, boolean paused, long configuredDurationMs,
-                        long configuredIncrementMs) {
+    public TimerUiState(
+            List<TimerItemUiModel> timers,
+            boolean paused,
+            long configuredDurationMs,
+            long configuredIncrementMs) {
         this.timers = new ArrayList<>(timers);
         this.paused = paused;
         this.configuredDurationMs = configuredDurationMs;

--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerUiState.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerUiState.java
@@ -7,11 +7,14 @@ public class TimerUiState {
     private final ArrayList<TimerItemUiModel> timers;
     private final boolean paused;
     private final long configuredDurationMs;
+    private final long configuredIncrementMs;
 
-    public TimerUiState(List<TimerItemUiModel> timers, boolean paused, long configuredDurationMs) {
+    public TimerUiState(List<TimerItemUiModel> timers, boolean paused, long configuredDurationMs,
+                        long configuredIncrementMs) {
         this.timers = new ArrayList<>(timers);
         this.paused = paused;
         this.configuredDurationMs = configuredDurationMs;
+        this.configuredIncrementMs = configuredIncrementMs;
     }
 
     public ArrayList<TimerItemUiModel> getTimers() {
@@ -24,5 +27,9 @@ public class TimerUiState {
 
     public long getConfiguredDurationMs() {
         return configuredDurationMs;
+    }
+
+    public long getConfiguredIncrementMs() {
+        return configuredIncrementMs;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerViewModel.java
@@ -19,7 +19,9 @@ public class TimerViewModel extends ViewModel {
     private static final String KEY_RUNNING_INDEX = "timer_running_index";
     private static final String KEY_IS_PAUSED = "timer_is_paused";
     private static final String KEY_CONFIGURED_DURATION = "timer_configured_duration";
+    private static final String KEY_CONFIGURED_INCREMENT = "timer_configured_increment";
     private static final long DEFAULT_DURATION_MS = 300000L;
+    private static final long DEFAULT_INCREMENT_MS = 0L;
 
     private final SavedStateHandle savedStateHandle;
     private final TimerStateStore timerStateStore;
@@ -31,6 +33,7 @@ public class TimerViewModel extends ViewModel {
     private int runningIndex;
     private boolean paused;
     private long configuredDurationMs;
+    private long configuredIncrementMs;
     private long lastTickTimeMs;
 
     public TimerViewModel(SavedStateHandle savedStateHandle, TimerStateStore timerStateStore,
@@ -62,6 +65,9 @@ public class TimerViewModel extends ViewModel {
         if (paused || remainingTimes.isEmpty()) {
             return;
         }
+        remainingTimes.set(
+                runningIndex,
+                remainingTimes.get(runningIndex) + configuredIncrementMs);
         runningIndex = (runningIndex + 1) % remainingTimes.size();
         lastTickTimeMs = timerScheduler.now();
         persistState();
@@ -69,8 +75,13 @@ public class TimerViewModel extends ViewModel {
     }
 
     public void editDuration(long durationMs) {
+        editDuration(durationMs, configuredIncrementMs);
+    }
+
+    public void editDuration(long durationMs, long incrementMs) {
         pauseTimer();
         configuredDurationMs = durationMs;
+        configuredIncrementMs = incrementMs;
         for (int i = 0; i < remainingTimes.size(); i++) {
             remainingTimes.set(i, durationMs);
         }
@@ -180,6 +191,7 @@ public class TimerViewModel extends ViewModel {
         Integer savedRunningIndex = savedStateHandle.get(KEY_RUNNING_INDEX);
         Boolean savedPaused = savedStateHandle.get(KEY_IS_PAUSED);
         Long savedConfiguredDuration = savedStateHandle.get(KEY_CONFIGURED_DURATION);
+        Long savedConfiguredIncrement = savedStateHandle.get(KEY_CONFIGURED_INCREMENT);
 
         if (savedRemainingTimes != null) {
             remainingTimes = new ArrayList<>(savedRemainingTimes);
@@ -188,6 +200,9 @@ public class TimerViewModel extends ViewModel {
             configuredDurationMs = savedConfiguredDuration == null
                     ? DEFAULT_DURATION_MS
                     : savedConfiguredDuration;
+            configuredIncrementMs = savedConfiguredIncrement == null
+                    ? DEFAULT_INCREMENT_MS
+                    : savedConfiguredIncrement;
             return;
         }
 
@@ -197,11 +212,13 @@ public class TimerViewModel extends ViewModel {
             runningIndex = snapshot.getRunningIndex();
             paused = snapshot.isPaused();
             configuredDurationMs = snapshot.getConfiguredDurationMs();
+            configuredIncrementMs = snapshot.getConfiguredIncrementMs();
             persistState();
             return;
         }
 
         configuredDurationMs = DEFAULT_DURATION_MS;
+        configuredIncrementMs = DEFAULT_INCREMENT_MS;
         remainingTimes = new ArrayList<>();
         remainingTimes.add(DEFAULT_DURATION_MS);
         remainingTimes.add(DEFAULT_DURATION_MS);
@@ -215,6 +232,7 @@ public class TimerViewModel extends ViewModel {
         savedStateHandle.set(KEY_RUNNING_INDEX, runningIndex);
         savedStateHandle.set(KEY_IS_PAUSED, paused);
         savedStateHandle.set(KEY_CONFIGURED_DURATION, configuredDurationMs);
+        savedStateHandle.set(KEY_CONFIGURED_INCREMENT, configuredIncrementMs);
     }
 
     private void emitState() {
@@ -230,7 +248,8 @@ public class TimerViewModel extends ViewModel {
                     remainingTime <= 0L
             ));
         }
-        uiState.setValue(new TimerUiState(timers, paused, configuredDurationMs));
+        uiState.setValue(
+                new TimerUiState(timers, paused, configuredDurationMs, configuredIncrementMs));
     }
 
     private String formatTime(long milliseconds) {
@@ -238,6 +257,11 @@ public class TimerViewModel extends ViewModel {
     }
 
     private TimerSnapshot createSnapshot() {
-        return new TimerSnapshot(remainingTimes, runningIndex, paused, configuredDurationMs);
+        return new TimerSnapshot(
+                remainingTimes,
+                runningIndex,
+                paused,
+                configuredDurationMs,
+                configuredIncrementMs);
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerViewModel.java
@@ -4,13 +4,10 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.SavedStateHandle;
 import androidx.lifecycle.ViewModel;
-
 import com.nicue.onetwo.core.TimerScheduler;
 import com.nicue.onetwo.data.timer.TimerSnapshot;
 import com.nicue.onetwo.data.timer.TimerStateStore;
-
 import com.nicue.onetwo.utils.TimerBackend;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,8 +33,10 @@ public class TimerViewModel extends ViewModel {
     private long configuredIncrementMs;
     private long lastTickTimeMs;
 
-    public TimerViewModel(SavedStateHandle savedStateHandle, TimerStateStore timerStateStore,
-                          TimerScheduler timerScheduler) {
+    public TimerViewModel(
+            SavedStateHandle savedStateHandle,
+            TimerStateStore timerStateStore,
+            TimerScheduler timerScheduler) {
         this.savedStateHandle = savedStateHandle;
         this.timerStateStore = timerStateStore;
         this.timerScheduler = timerScheduler;
@@ -65,9 +64,7 @@ public class TimerViewModel extends ViewModel {
         if (paused || remainingTimes.isEmpty()) {
             return;
         }
-        remainingTimes.set(
-                runningIndex,
-                remainingTimes.get(runningIndex) + configuredIncrementMs);
+        remainingTimes.set(runningIndex, remainingTimes.get(runningIndex) + configuredIncrementMs);
         runningIndex = (runningIndex + 1) % remainingTimes.size();
         lastTickTimeMs = timerScheduler.now();
         persistState();
@@ -146,12 +143,13 @@ public class TimerViewModel extends ViewModel {
         }
         paused = false;
         lastTickTimeMs = timerScheduler.now();
-        timerScheduler.start(new TimerScheduler.TickListener() {
-            @Override
-            public void onTick(long nowMs) {
-                handleTick(nowMs);
-            }
-        });
+        timerScheduler.start(
+                new TimerScheduler.TickListener() {
+                    @Override
+                    public void onTick(long nowMs) {
+                        handleTick(nowMs);
+                    }
+                });
         persistState();
         emitState();
     }
@@ -197,12 +195,12 @@ public class TimerViewModel extends ViewModel {
             remainingTimes = new ArrayList<>(savedRemainingTimes);
             runningIndex = savedRunningIndex == null ? 0 : savedRunningIndex;
             paused = savedPaused == null || savedPaused;
-            configuredDurationMs = savedConfiguredDuration == null
-                    ? DEFAULT_DURATION_MS
-                    : savedConfiguredDuration;
-            configuredIncrementMs = savedConfiguredIncrement == null
-                    ? DEFAULT_INCREMENT_MS
-                    : savedConfiguredIncrement;
+            configuredDurationMs =
+                    savedConfiguredDuration == null ? DEFAULT_DURATION_MS : savedConfiguredDuration;
+            configuredIncrementMs =
+                    savedConfiguredIncrement == null
+                            ? DEFAULT_INCREMENT_MS
+                            : savedConfiguredIncrement;
             return;
         }
 
@@ -240,13 +238,13 @@ public class TimerViewModel extends ViewModel {
         for (int i = 0; i < remainingTimes.size(); i++) {
             long remainingTime = remainingTimes.get(i);
             boolean active = i == runningIndex;
-            timers.add(new TimerItemUiModel(
-                    remainingTime,
-                    formatTime(remainingTime),
-                    active,
-                    active && !paused && remainingTime > 0L,
-                    remainingTime <= 0L
-            ));
+            timers.add(
+                    new TimerItemUiModel(
+                            remainingTime,
+                            formatTime(remainingTime),
+                            active,
+                            active && !paused && remainingTime > 0L,
+                            remainingTime <= 0L));
         }
         uiState.setValue(
                 new TimerUiState(timers, paused, configuredDurationMs, configuredIncrementMs));
@@ -258,10 +256,6 @@ public class TimerViewModel extends ViewModel {
 
     private TimerSnapshot createSnapshot() {
         return new TimerSnapshot(
-                remainingTimes,
-                runningIndex,
-                paused,
-                configuredDurationMs,
-                configuredIncrementMs);
+                remainingTimes, runningIndex, paused, configuredDurationMs, configuredIncrementMs);
     }
 }

--- a/app/src/main/res/layout/minutes_alert_dialog.xml
+++ b/app/src/main/res/layout/minutes_alert_dialog.xml
@@ -1,26 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:gravity="center"
-    android:layout_height="match_parent">
-
-    <NumberPicker
-        android:id="@+id/minute_picker"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"/>
+    android:layout_height="wrap_content">
 
     <TextView
+        android:id="@+id/base_time_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="@string/colon"/>
-    <NumberPicker
-        android:id="@+id/seconds_picker"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"/>
+        android:layout_marginBottom="8dp"
+        android:text="@string/timer_base_time_label" />
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <NumberPicker
+            android:id="@+id/minute_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/colon" />
+
+        <NumberPicker
+            android:id="@+id/seconds_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/increment_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/timer_increment_label" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <NumberPicker
+            android:id="@+id/increment_minute_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/colon" />
+
+        <NumberPicker
+            android:id="@+id/increment_seconds_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,9 @@
     <string name="order">Order</string>
     <string name="play">Play</string>
     <string name="pause">Pause</string>
+    <string name="timer_settings_title">Timer settings</string>
+    <string name="timer_base_time_label">Base time</string>
+    <string name="timer_increment_label">Increment per play</string>
     <string name="counter_instruction">Press the button to add a counter or swipe right for more options</string>
     <!-- Preference Titles -->
     <string name="ui_header">UI</string>

--- a/app/src/test/java/com/nicue/onetwo/ui/timer/TimerViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/timer/TimerViewModelTest.java
@@ -6,11 +6,9 @@ import static org.junit.Assert.assertTrue;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.SavedStateHandle;
-
 import com.nicue.onetwo.LiveDataTestUtil;
 import com.nicue.onetwo.core.TimerScheduler;
 import com.nicue.onetwo.data.timer.TimerStateStore;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,17 +18,13 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
 public class TimerViewModelTest {
-    @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     @Test
     public void timerStateTransitions_areOwnedByViewModel() throws Exception {
         FakeTimerScheduler scheduler = new FakeTimerScheduler();
-        TimerViewModel viewModel = new TimerViewModel(
-                new SavedStateHandle(),
-                new TimerStateStore(),
-                scheduler
-        );
+        TimerViewModel viewModel =
+                new TimerViewModel(new SavedStateHandle(), new TimerStateStore(), scheduler);
 
         TimerUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertTrue(state.isPaused());
@@ -58,11 +52,8 @@ public class TimerViewModelTest {
     @Test
     public void advanceTimer_appliesIncrementToCompletedTurn() throws Exception {
         FakeTimerScheduler scheduler = new FakeTimerScheduler();
-        TimerViewModel viewModel = new TimerViewModel(
-                new SavedStateHandle(),
-                new TimerStateStore(),
-                scheduler
-        );
+        TimerViewModel viewModel =
+                new TimerViewModel(new SavedStateHandle(), new TimerStateStore(), scheduler);
 
         viewModel.editDuration(10_000L, 2_000L);
         viewModel.togglePlayPause();

--- a/app/src/test/java/com/nicue/onetwo/ui/timer/TimerViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/timer/TimerViewModelTest.java
@@ -55,6 +55,27 @@ public class TimerViewModelTest {
         assertEquals(0L, state.getTimers().get(1).getRemainingTimeMs());
     }
 
+    @Test
+    public void advanceTimer_appliesIncrementToCompletedTurn() throws Exception {
+        FakeTimerScheduler scheduler = new FakeTimerScheduler();
+        TimerViewModel viewModel = new TimerViewModel(
+                new SavedStateHandle(),
+                new TimerStateStore(),
+                scheduler
+        );
+
+        viewModel.editDuration(10_000L, 2_000L);
+        viewModel.togglePlayPause();
+        scheduler.advanceBy(3_000L);
+
+        viewModel.advanceTimer();
+
+        TimerUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertEquals(9_000L, state.getTimers().get(0).getRemainingTimeMs());
+        assertEquals(2_000L, state.getConfiguredIncrementMs());
+        assertTrue(state.getTimers().get(1).isActive());
+    }
+
     private static class FakeTimerScheduler implements TimerScheduler {
         private TickListener tickListener;
         private long nowMs;


### PR DESCRIPTION
## Summary
- Added per-play increment support to the timer state and persistence flow.
- Updated the timer edit dialog to let users configure both base time and increment.
- Applied the configured increment when advancing to the next player, matching chess-clock behavior.
- Added unit coverage for increment handoff and state persistence.

## Testing
- `./gradlew testDebugUnitTest --tests com.nicue.onetwo.ui.timer.TimerViewModelTest --tests com.nicue.onetwo.ui.timer.TimerFragmentTest`