### PR TITLE
Restore light-mode counter and timer colors while keeping nav bar fixed

### DIFF
--- a/app/src/main/java/com/nicue/onetwo/ui/timer/TimerFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/timer/TimerFragment.java
@@ -16,6 +16,7 @@ import android.widget.NumberPicker;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
 import androidx.core.view.MenuHost;
 import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
@@ -238,10 +239,7 @@ public class TimerFragment extends Fragment implements MenuProvider {
         return timer.isActive() && timer.isEnabled()
                 ? MaterialColors.getColor(
                         context, com.google.android.material.R.attr.colorTertiary, "TimerFragment")
-                : MaterialColors.getColor(
-                        context,
-                        com.google.android.material.R.attr.colorTertiaryContainer,
-                        "TimerFragment");
+                : ContextCompat.getColor(context, R.color.timer_idle_background);
     }
 
     private int resolveTextColor(TimerItemUiModel timer) {
@@ -257,10 +255,7 @@ public class TimerFragment extends Fragment implements MenuProvider {
                         context,
                         com.google.android.material.R.attr.colorOnTertiary,
                         "TimerFragment")
-                : MaterialColors.getColor(
-                        context,
-                        com.google.android.material.R.attr.colorOnTertiaryContainer,
-                        "TimerFragment");
+                : ContextCompat.getColor(context, R.color.timer_idle_foreground);
     }
 
     private void vibrate(long milliseconds) {

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="192dp"
-    android:background="?attr/colorPrimary"
+    android:background="@color/colorPrimary"
     android:padding="@dimen/space_m"
     android:theme="@style/ThemeOverlay.Material3.Dark"
     android:orientation="vertical"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -39,6 +39,10 @@
     <color name="m3_on_error">#690005</color>
     <color name="m3_error_container">#93000A</color>
     <color name="m3_on_error_container">#FFDAD6</color>
+    <color name="navigation_bar_background">#FFFBFF</color>
+    <color name="counter_adjust_button_background">@color/m3_secondary_container</color>
+    <color name="timer_idle_background">@color/m3_tertiary_container</color>
+    <color name="timer_idle_foreground">@color/m3_on_tertiary_container</color>
 
     <color name="diceColor0">#850009</color>
     <color name="diceColor1">#b9d529</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -39,6 +39,10 @@
     <color name="m3_on_error">#FFFFFFFF</color>
     <color name="m3_error_container">#FFDAD6</color>
     <color name="m3_on_error_container">#410002</color>
+    <color name="navigation_bar_background">@color/m3_surface</color>
+    <color name="counter_adjust_button_background">#26FFE08A</color>
+    <color name="timer_idle_background">#850009</color>
+    <color name="timer_idle_foreground">@color/m3_on_tertiary</color>
 
     <color name="diceColor0">#083E64</color>
     <color name="diceColor1">#F3BB21</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,7 +37,7 @@
         <item name="colorErrorContainer">@color/m3_error_container</item>
         <item name="colorOnErrorContainer">@color/m3_on_error_container</item>
         <item name="android:statusBarColor">@color/m3_primary</item>
-        <item name="android:navigationBarColor">@color/m3_surface</item>
+        <item name="android:navigationBarColor">@color/navigation_bar_background</item>
         <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.OneTwo.Small</item>
         <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.OneTwo.Container</item>
         <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.OneTwo.Large</item>
@@ -79,7 +79,7 @@
 
     <style name="Widget.OneTwo.FilledIconButton" parent="Widget.Material3.Button.IconButton.Filled.Tonal">
         <item name="iconTint">?attr/colorPrimary</item>
-        <item name="backgroundTint">?attr/colorSecondaryContainer</item>
+        <item name="backgroundTint">@color/counter_adjust_button_background</item>
     </style>
 
     <style name="Widget.OneTwo.DeleteIconButton" parent="Widget.Material3.Button.IconButton.Filled">


### PR DESCRIPTION
## Summary
- Restore the pre-May 18 light-mode tint for the counter adjust buttons while keeping the newer dark-mode palette.
- Restore the inactive timer tile/button colors in light mode and keep the theme-aware dark-mode values.
- Keep the navigation bar on the light-mode surface color in both themes.

## Testing
- `./gradlew testDebugUnitTest`