### PR TITLE
feat: set MTG life counter as default destination and rename menu tabs 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 32
-        versionName "1.10.0"
+        versionCode 33
+        versionName "1.11.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/MainActivity.java
+++ b/app/src/main/java/com/nicue/onetwo/MainActivity.java
@@ -42,11 +42,11 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
         NavController navController = navHostFragment.getNavController();
         appBarConfiguration =
                 new AppBarConfiguration.Builder(
-                                R.id.nav_counter,
+                                R.id.nav_mtg_life,
                                 R.id.nav_dice,
                                 R.id.nav_chooser,
                                 R.id.nav_timer,
-                                R.id.nav_mtg_life,
+                                R.id.nav_counter,
                                 R.id.nav_settings)
                         .setOpenableLayout(binding.drawerLayout)
                         .build();

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -168,6 +168,7 @@ public class MtgLifeViewModel extends ViewModel {
                 parsedStartingLife == null ? R.string.mtg_setup_life_error : null);
 
         if (parsedPlayerCount == null || parsedStartingLife == null) {
+            savedStateHandle.set(KEY_SHOWING_SETUP, true);
             updateUiState();
             return;
         }
@@ -332,16 +333,21 @@ public class MtgLifeViewModel extends ViewModel {
     }
 
     private void initializeDefaultState() {
-        savedStateHandle.set(KEY_SHOWING_SETUP, true);
+        savedStateHandle.set(KEY_SHOWING_SETUP, false);
         savedStateHandle.set(KEY_PLAYER_COUNT, DEFAULT_PLAYER_COUNT);
         savedStateHandle.set(KEY_STARTING_LIFE, DEFAULT_STARTING_LIFE);
-        savedStateHandle.set(KEY_CURRENT_LIVES, new ArrayList<Integer>());
-        savedStateHandle.set(KEY_RECENT_LIFE_CHANGES, new ArrayList<Integer>());
-        savedStateHandle.set(KEY_RECENT_LIFE_CHANGE_TIMESTAMPS, new ArrayList<Long>());
+        savedStateHandle.set(
+                KEY_CURRENT_LIVES, createInitialLives(DEFAULT_PLAYER_COUNT, DEFAULT_STARTING_LIFE));
+        savedStateHandle.set(
+                KEY_RECENT_LIFE_CHANGES, createInitialRecentLifeChanges(DEFAULT_PLAYER_COUNT));
+        savedStateHandle.set(
+                KEY_RECENT_LIFE_CHANGE_TIMESTAMPS,
+                createInitialRecentLifeChangeTimestamps(DEFAULT_PLAYER_COUNT));
         savedStateHandle.set(KEY_PLAYERS_ERROR_RES_ID, null);
         savedStateHandle.set(KEY_LIFE_ERROR_RES_ID, null);
         savedStateHandle.set(KEY_COMMANDER_DAMAGE_ENABLED, true);
-        savedStateHandle.set(KEY_COMMANDER_DAMAGE_MATRIX, new ArrayList<ArrayList<Integer>>());
+        savedStateHandle.set(
+                KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(DEFAULT_PLAYER_COUNT));
 
         savedStateHandle.set(KEY_TURN_TIMER_ENABLED, false);
         savedStateHandle.set(KEY_TURN_TIMER_DURATION_MS, DEFAULT_TURN_TIMER_DURATION_MS);

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -4,10 +4,10 @@
         android:id="@+id/menu_top"
         android:checkableBehavior="single">
         <item
-            android:id="@+id/nav_counter"
-            android:icon="@drawable/counter"
+            android:id="@+id/nav_mtg_life"
+            android:icon="@drawable/cards_playing_outline"
             android:checked="true"
-            android:title="@string/menu_counter" />
+            android:title="@string/menu_mtg_life" />
         <item
             android:id="@+id/nav_dice"
             android:icon="@drawable/dice_multiple"
@@ -24,9 +24,9 @@
             android:title="@string/menu_timer" />
 
         <item
-            android:id="@+id/nav_mtg_life"
-            android:icon="@drawable/cards_playing_outline"
-            android:title="@string/menu_mtg_life" />
+            android:id="@+id/nav_counter"
+            android:icon="@drawable/counter"
+            android:title="@string/menu_counter" />
 
     </group>
 

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -2,7 +2,7 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_nav_graph"
-    app:startDestination="@id/nav_counter">
+    app:startDestination="@id/nav_mtg_life">
 
     <fragment
         android:id="@+id/nav_counter"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,9 +14,9 @@
     <string name="counter_subtract_amount_content_description">Restar cantidad del contador</string>
     <string name="alert_tv_object">¿Quién está jugando?</string>
     <string name="alert_tv_number">Vidas/Puntos: </string>
-    <string name="menu_counter">Contador</string>
+    <string name="menu_counter">Contadores</string>
     <string name="menu_dice">Dados</string>
-    <string name="menu_counter_space">&#160;Contador</string>
+    <string name="menu_counter_space">&#160;Contadores</string>
     <string name="menu_dice_space">&#160;Dados</string>
     <string name="menu_chooser_space">&#160;Elegir</string>
     <string name="menu_timer_space">&#160;Temporizador</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,11 +14,11 @@
     <string name="counter_subtract_amount_content_description">Soustraire une quantité du score</string>
     <string name="alert_tv_object">Qui joue?</string>
     <string name="alert_tv_number">Vies/Score</string>
-    <string name="menu_counter">Score</string>
+    <string name="menu_counter">Scores</string>
     <string name="menu_dice">Dé</string>
     <string name="menu_chooser">Choisir</string>
     <string name="menu_timer">Minuteur</string>
-    <string name="menu_counter_space">Score</string>
+    <string name="menu_counter_space">Scores</string>
     <string name="menu_dice_space">Dé</string>
     <string name="menu_chooser_space">Choisir</string>
     <string name="menu_timer_space">Minuteur</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,12 +14,12 @@
     <string name="counter_subtract_amount_content_description">Subtract amount from counter</string>
     <string name="alert_tv_object">Who\'s Playing?</string>
     <string name="alert_tv_number">Lives/Score: </string>
-    <string name="menu_counter">Counter</string>
+    <string name="menu_counter">Counters</string>
     <string name="menu_dice">Dice</string>
     <string name="menu_chooser">Choose</string>
     <string name="menu_timer">Timer</string>
     <string name="menu_settings">Settings</string>
-    <string name="menu_counter_space">&#160;Counter</string>
+    <string name="menu_counter_space">&#160;Counters</string>
     <string name="menu_dice_space">&#160;Dice</string>
     <string name="menu_chooser_space">&#160;Choose</string>
     <string name="menu_timer_space">&#160;Timer</string>

--- a/app/src/test/java/com/nicue/onetwo/navigation/NavigationSmokeTest.java
+++ b/app/src/test/java/com/nicue/onetwo/navigation/NavigationSmokeTest.java
@@ -30,7 +30,7 @@ public class NavigationSmokeTest {
                         NavController navController =
                                 ((NavHostFragment) fragment).getNavController();
                         assertEquals(
-                                R.id.nav_counter, navController.getCurrentDestination().getId());
+                                R.id.nav_mtg_life, navController.getCurrentDestination().getId());
 
                         navController.navigate(R.id.nav_dice);
                         assertEquals(R.id.nav_dice, navController.getCurrentDestination().getId());

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -32,7 +32,7 @@ public class MtgLifeFragmentTest {
     @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     @Test
-    public void testSetupStateVisibleOnFirstLaunchAndPrefilled() {
+    public void testSetupStateHiddenOnFirstLaunchAndPrefilledOnNewGame() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
@@ -43,11 +43,27 @@ public class MtgLifeFragmentTest {
 
                         View setupContent = view.findViewById(R.id.setup_content);
                         assertNotNull(setupContent);
-                        assertEquals(View.VISIBLE, setupContent.getVisibility());
+                        assertEquals(View.GONE, setupContent.getVisibility());
 
                         View boardContainer = view.findViewById(R.id.board_container);
                         assertNotNull(boardContainer);
                         assertEquals(View.VISIBLE, boardContainer.getVisibility());
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        View view = fragment.getView();
+                        assertNotNull(view);
+
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertEquals(View.VISIBLE, setupContent.getVisibility());
 
                         EditText playersInput = view.findViewById(R.id.players_input);
                         EditText lifeInput = view.findViewById(R.id.life_input);
@@ -66,9 +82,12 @@ public class MtgLifeFragmentTest {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-            // 1. Press Start Game with defaults (4 players, 40 life)
             scenario.onFragment(
                     fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+
                         View view = fragment.getView();
                         assertNotNull(view);
                         Button startButton = view.findViewById(R.id.start_game_button);
@@ -76,7 +95,6 @@ public class MtgLifeFragmentTest {
                         startButton.performClick();
                     });
 
-            // 2. Verify we transitioned to playing board state (4 players board)
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -87,8 +105,6 @@ public class MtgLifeFragmentTest {
                         View boardContainer = view.findViewById(R.id.board_container);
                         assertEquals(View.VISIBLE, boardContainer.getVisibility());
 
-                        // 4-player board is inflated, check that R.id.player_1, player_2, player_3,
-                        // player_4 are present
                         View player1 = view.findViewById(R.id.player_1);
                         View player2 = view.findViewById(R.id.player_2);
                         View player3 = view.findViewById(R.id.player_3);
@@ -99,7 +115,6 @@ public class MtgLifeFragmentTest {
                         assertNotNull(player3);
                         assertNotNull(player4);
 
-                        // Verify starting life totals are 40
                         TextView life1 = player1.findViewById(R.id.tv_life_count);
                         TextView life2 = player2.findViewById(R.id.tv_life_count);
                         TextView negativeChange1 =
@@ -117,18 +132,15 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.GONE, negativeChange2.getVisibility());
                         assertEquals(View.GONE, positiveChange2.getVisibility());
 
-                        // Tap right half for player 1
                         View incrementZone1 = player1.findViewById(R.id.life_increment_zone);
                         assertNotNull(incrementZone1);
                         incrementZone1.performClick();
 
-                        // Tap left half for player 2
                         View decrementZone2 = player2.findViewById(R.id.life_decrement_zone);
                         assertNotNull(decrementZone2);
                         decrementZone2.performClick();
                     });
 
-            // 3. Verify life totals are updated accordingly
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -166,9 +178,12 @@ public class MtgLifeFragmentTest {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-            // 1. Enter non-default setup, e.g., 3 players, 30 life, and start game
             scenario.onFragment(
                     fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+
                         View view = fragment.getView();
                         assertNotNull(view);
                         EditText playersInput = view.findViewById(R.id.players_input);
@@ -180,7 +195,6 @@ public class MtgLifeFragmentTest {
                         startButton.performClick();
                     });
 
-            // 2. Verify we are playing 3 players game
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -200,7 +214,6 @@ public class MtgLifeFragmentTest {
                         assertEquals("30", life1.getText().toString());
                     });
 
-            // 3. Trigger app-bar "New Game" menu action (action_new_game)
             scenario.onFragment(
                     fragment -> {
                         org.robolectric.fakes.RoboMenuItem resetMenuItem =
@@ -208,9 +221,6 @@ public class MtgLifeFragmentTest {
                         fragment.onMenuItemSelected(resetMenuItem);
                     });
 
-            // 4. Verify we are back on the setup screen and inputs are prefilled with last-used
-            // values
-            // (3 and 30)
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -234,16 +244,6 @@ public class MtgLifeFragmentTest {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-            // 1. Start a game with default settings
-            scenario.onFragment(
-                    fragment -> {
-                        View view = fragment.getView();
-                        assertNotNull(view);
-                        Button startButton = view.findViewById(R.id.start_game_button);
-                        startButton.performClick();
-                    });
-
-            // 2. Go back to setup screen via menu action
             scenario.onFragment(
                     fragment -> {
                         org.robolectric.fakes.RoboMenuItem resetMenuItem =
@@ -251,7 +251,6 @@ public class MtgLifeFragmentTest {
                         fragment.onMenuItemSelected(resetMenuItem);
                     });
 
-            // 3. Verify setup overlay is visible
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -260,7 +259,6 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.VISIBLE, setupOverlay.getVisibility());
                     });
 
-            // 4. Tap the overlay (clicking outside the card)
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -269,7 +267,6 @@ public class MtgLifeFragmentTest {
                         setupOverlay.performClick();
                     });
 
-            // 5. Verify setup overlay is now GONE (modal dismissed/escaped)
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -284,14 +281,6 @@ public class MtgLifeFragmentTest {
     public void testCommanderDamageDialogHalfTapZonesUpdateSummary() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
-
-            scenario.onFragment(
-                    fragment -> {
-                        View view = fragment.getView();
-                        assertNotNull(view);
-                        Button startButton = view.findViewById(R.id.start_game_button);
-                        startButton.performClick();
-                    });
 
             scenario.onFragment(
                     fragment -> {
@@ -351,15 +340,6 @@ public class MtgLifeFragmentTest {
 
             scenario.onFragment(
                     fragment -> {
-                        View view = fragment.getView();
-                        assertNotNull(view);
-                        Button startButton = view.findViewById(R.id.start_game_button);
-                        assertNotNull(startButton);
-                        startButton.performClick();
-                    });
-
-            scenario.onFragment(
-                    fragment -> {
                         View view = fragment.requireView();
                         View player1 = view.findViewById(R.id.player_1);
                         View player2 = view.findViewById(R.id.player_2);
@@ -407,14 +387,6 @@ public class MtgLifeFragmentTest {
     public void testRecentLifeChangeDoesNotRestartAnimationForSameTimestamp() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
-
-            scenario.onFragment(
-                    fragment -> {
-                        View view = fragment.requireView();
-                        Button startButton = view.findViewById(R.id.start_game_button);
-                        assertNotNull(startButton);
-                        startButton.performClick();
-                    });
 
             scenario.onFragment(
                     fragment -> {
@@ -469,9 +441,12 @@ public class MtgLifeFragmentTest {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-            // 1. Enter 5 players setup and start game
             scenario.onFragment(
                     fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+
                         View view = fragment.getView();
                         assertNotNull(view);
                         EditText playersInput = view.findViewById(R.id.players_input);
@@ -483,7 +458,6 @@ public class MtgLifeFragmentTest {
                         startButton.performClick();
                     });
 
-            // 2. Open commander damage dialog for player 5 (seat 4)
             scenario.onFragment(
                     fragment -> {
                         View player5 = fragment.requireView().findViewById(R.id.player_5);
@@ -510,10 +484,6 @@ public class MtgLifeFragmentTest {
                                 decorView.findViewWithTag("commander_dialog_content");
                         assertNotNull(dialogContent);
 
-                        // Verify that row 0 has the expected cells:
-                        // Col 0: Player 1 (source seat 0) -> visible
-                        // Col 1: Player 2 (source seat 1) -> visible
-                        // Col 2: Player 5 (source seat 4, self) -> invisible
                         android.widget.LinearLayout row0 =
                                 (android.widget.LinearLayout) dialogContent.getChildAt(0);
                         View cell0 = row0.getChildAt(0);
@@ -524,7 +494,6 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.VISIBLE, cell1.getVisibility());
                         assertEquals(View.INVISIBLE, cell2.getVisibility());
 
-                        // Verify increment zones exist in cell0 and cell1
                         View incZone0 =
                                 findViewWithContentDescription(
                                         cell0,
@@ -538,10 +507,6 @@ public class MtgLifeFragmentTest {
                         assertNotNull(incZone0);
                         assertNotNull(incZone1);
 
-                        // Verify that row 1 has the expected cells:
-                        // Col 0: Player 3 (source seat 2) -> visible
-                        // Col 1: Player 4 (source seat 3) -> visible
-                        // Col 2: Spacer (seat 5) -> invisible
                         android.widget.LinearLayout row1 =
                                 (android.widget.LinearLayout) dialogContent.getChildAt(1);
                         View cell3 = row1.getChildAt(0);
@@ -572,15 +537,6 @@ public class MtgLifeFragmentTest {
     public void testHoldingLifeZoneRepeatsTenPointChangeEveryOnePointFiveSeconds() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
-
-            scenario.onFragment(
-                    fragment -> {
-                        View view = fragment.getView();
-                        assertNotNull(view);
-                        Button startButton = view.findViewById(R.id.start_game_button);
-                        assertNotNull(startButton);
-                        startButton.performClick();
-                    });
 
             scenario.onFragment(
                     fragment -> {
@@ -623,6 +579,10 @@ public class MtgLifeFragmentTest {
 
             scenario.onFragment(
                     fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+
                         View view = fragment.getView();
                         assertNotNull(view);
                         EditText playersInput = view.findViewById(R.id.players_input);
@@ -654,6 +614,10 @@ public class MtgLifeFragmentTest {
 
             scenario.onFragment(
                     fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+
                         View view = fragment.getView();
                         assertNotNull(view);
                         EditText playersInput = view.findViewById(R.id.players_input);
@@ -704,9 +668,12 @@ public class MtgLifeFragmentTest {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
-            // 1. Enable turn timer switch and start a game
             scenario.onFragment(
                     fragment -> {
+                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        fragment.onMenuItemSelected(resetMenuItem);
+
                         View view = fragment.getView();
                         assertNotNull(view);
 
@@ -720,7 +687,6 @@ public class MtgLifeFragmentTest {
                         startButton.performClick();
                     });
 
-            // 2. Verify we are in game and player cells have timer visible
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();
@@ -733,7 +699,6 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.VISIBLE, timerContainer.getVisibility());
                     });
 
-            // 3. Return to setup (New Game)
             scenario.onFragment(
                     fragment -> {
                         org.robolectric.fakes.RoboMenuItem resetMenuItem =
@@ -741,7 +706,6 @@ public class MtgLifeFragmentTest {
                         fragment.onMenuItemSelected(resetMenuItem);
                     });
 
-            // 4. Verify that on returning to setup, the preview player cell has timer GONE
             scenario.onFragment(
                     fragment -> {
                         View view = fragment.getView();

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -47,12 +47,12 @@ public class MtgLifeViewModelTest {
     @Test
     public void testDefaultSetupState() throws Exception {
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
-        assertTrue(state.isShowingSetup());
+        assertFalse(state.isShowingSetup());
         assertEquals(4, state.getPlayerCount());
         assertEquals(40, state.getStartingLife());
         assertNull(state.getPlayersErrorResId());
         assertNull(state.getLifeErrorResId());
-        assertTrue(state.getPlayers().isEmpty());
+        assertEquals(4, state.getPlayers().size());
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR prepares the application for release version 1.11.0 (build 33). It replaces launcher icons, reorders primary drawer tabs to prioritize the MTG Life Counter, renames "Counter" to "Counters" (with translations), and updates the MTG Life Counter to bypass the initial setup overlay by starting a default game directly on launch.

## Key Changes
1. Launcher & Store Assets Update
Generated and replaced legacy, round, and adaptive launcher icons across all resolution buckets (mdpi, hdpi, xhdpi, xxhdpi, and xxxhdpi).
Extracted transparent foreground layer (ic_launcher_foreground.png) to support adaptive icons properly on top of the primary background color.
Updated high-resolution store graphics big_icon.png and OneTwoIcon-play-512.png in /imgs.
2. Tab Reordering & Renaming
Navigation Menu & Graph: Positioned "Life Counter" (nav_mtg_life) at the top of the navigation drawer (drawer_view.xml) and set it as the start destination of main_nav_graph.xml.
Naming: Renamed "Counter" to "Counters" in primary resource bundles, updating Spanish to Contadores and French to Scores.
Top-level Config: Reordered top-level configuration IDs in MainActivity.java to align with the new layout order.
3. MTG Life Counter UX Improvements
Start Game on Launch: Modified default initialization state in MtgLifeViewModel to set showingSetup to false and pre-initialize a standard 4-player, 40-life game board automatically.
Validation Guard: Added validation error handling inside validateAndStartGame() to ensure showingSetup toggles to true when inputs fail validation, making setup overlays with error messages properly visible.
4. Code & Test Quality
Bumped versionCode to 33 and versionName to "1.11.0" in app/build.gradle.
Updated test suites in MtgLifeViewModelTest.java, MtgLifeFragmentTest.java, and NavigationSmokeTest.java to assert the new default starting states, navigation graph start destination, and custom setup flows.

## Verification Results

### Automated Tests
Ran local JVM unit tests using ./gradlew testDebugUnitTest:

Result: BUILD SUCCESSFUL (all tests passed).
All Robolectric fragment tests and ViewModel integration tests successfully verified the direct-to-board start experience as well as setup-menu validation errors.