### PR TITLE
feat: Allow player choosing from life counter fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 33
-        versionName "1.11.0"
+        versionCode 34
+        versionName "1.12.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -84,6 +84,30 @@ public class ChooserFragment extends Fragment {
                     new com.nicue.onetwo.utils.TouchDisplayView.OnSelectionListener() {
                         @Override
                         public void onSelectionMade() {
+                            if (arguments != null && arguments.containsKey("player_count")) {
+                                int playerCount = arguments.getInt("player_count", 0);
+                                if (playerCount >= 1 && playerCount <= 6) {
+                                    float chosenX = binding.chooserView.getSelectionRevealCenterX();
+                                    float chosenY = binding.chooserView.getSelectionRevealCenterY();
+                                    int width = binding.chooserView.getWidth();
+                                    int height = binding.chooserView.getHeight();
+                                    if (width > 0 && height > 0) {
+                                        int closestSeatIndex = getClosestSeatIndex(chosenX, chosenY, width, height, playerCount);
+                                        try {
+                                            androidx.navigation.NavBackStackEntry prevEntry =
+                                                    androidx.navigation.fragment.NavHostFragment
+                                                            .findNavController(ChooserFragment.this)
+                                                            .getPreviousBackStackEntry();
+                                            if (prevEntry != null) {
+                                                prevEntry.getSavedStateHandle().set("chosen_seat_index", closestSeatIndex);
+                                            }
+                                        } catch (Exception e) {
+                                            // Handle/ignore if navigation entry not available
+                                        }
+                                    }
+                                }
+                            }
+
                             if (navigateBackRunnable != null) {
                                 handler.removeCallbacks(navigateBackRunnable);
                             }
@@ -136,5 +160,106 @@ public class ChooserFragment extends Fragment {
         }
         handler.removeCallbacks(hideInstructionRunnable);
         handler.postDelayed(hideInstructionRunnable, INSTRUCTION_HIDE_DELAY_MS);
+    }
+
+    static float[] getSeatCenter(int seatIndex, int playerCount, float width, float height) {
+        float x = width / 2f;
+        float y = height / 2f;
+
+        switch (playerCount) {
+            case 1:
+                break;
+            case 2:
+                if (seatIndex == 0) {
+                    y = height / 4f;
+                } else if (seatIndex == 1) {
+                    y = 3f * height / 4f;
+                }
+                break;
+            case 3:
+                if (seatIndex == 0) {
+                    y = 3f * height / 4f;
+                } else if (seatIndex == 1) {
+                    x = width / 4f;
+                    y = height / 4f;
+                } else if (seatIndex == 2) {
+                    x = 3f * width / 4f;
+                    y = height / 4f;
+                }
+                break;
+            case 4:
+                if (seatIndex == 0) {
+                    x = width / 4f;
+                    y = height / 4f;
+                } else if (seatIndex == 1) {
+                    x = 3f * width / 4f;
+                    y = height / 4f;
+                } else if (seatIndex == 2) {
+                    x = width / 4f;
+                    y = 3f * height / 4f;
+                } else if (seatIndex == 3) {
+                    x = 3f * width / 4f;
+                    y = 3f * height / 4f;
+                }
+                break;
+            case 5:
+                if (seatIndex == 0) {
+                    x = width / 4f;
+                    y = height / 6f;
+                } else if (seatIndex == 1) {
+                    x = 3f * width / 4f;
+                    y = height / 6f;
+                } else if (seatIndex == 2) {
+                    x = width / 4f;
+                    y = height / 2f;
+                } else if (seatIndex == 3) {
+                    x = 3f * width / 4f;
+                    y = height / 2f;
+                } else if (seatIndex == 4) {
+                    y = 5f * height / 6f;
+                }
+                break;
+            case 6:
+                if (seatIndex == 0) {
+                    x = width / 4f;
+                    y = height / 6f;
+                } else if (seatIndex == 1) {
+                    x = 3f * width / 4f;
+                    y = height / 6f;
+                } else if (seatIndex == 2) {
+                    x = width / 4f;
+                    y = height / 2f;
+                } else if (seatIndex == 3) {
+                    x = 3f * width / 4f;
+                    y = height / 2f;
+                } else if (seatIndex == 4) {
+                    x = width / 4f;
+                    y = 5f * height / 6f;
+                } else if (seatIndex == 5) {
+                    x = 3f * width / 4f;
+                    y = 5f * height / 6f;
+                }
+                break;
+        }
+
+        return new float[]{x, y};
+    }
+
+    static int getClosestSeatIndex(float touchX, float touchY, float width, float height, int playerCount) {
+        int closestIndex = 0;
+        double minDistanceSq = Double.MAX_VALUE;
+
+        for (int i = 0; i < playerCount; i++) {
+            float[] center = getSeatCenter(i, playerCount, width, height);
+            double dx = touchX - center[0];
+            double dy = touchY - center[1];
+            double distanceSq = dx * dx + dy * dy;
+            if (distanceSq < minDistanceSq) {
+                minDistanceSq = distanceSq;
+                closestIndex = i;
+            }
+        }
+
+        return closestIndex;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -92,14 +92,22 @@ public class ChooserFragment extends Fragment {
                                     int width = binding.chooserView.getWidth();
                                     int height = binding.chooserView.getHeight();
                                     if (width > 0 && height > 0) {
-                                        int closestSeatIndex = getClosestSeatIndex(chosenX, chosenY, width, height, playerCount);
+                                        int closestSeatIndex =
+                                                getClosestSeatIndex(
+                                                        chosenX,
+                                                        chosenY,
+                                                        width,
+                                                        height,
+                                                        playerCount);
                                         try {
                                             androidx.navigation.NavBackStackEntry prevEntry =
                                                     androidx.navigation.fragment.NavHostFragment
                                                             .findNavController(ChooserFragment.this)
                                                             .getPreviousBackStackEntry();
                                             if (prevEntry != null) {
-                                                prevEntry.getSavedStateHandle().set("chosen_seat_index", closestSeatIndex);
+                                                prevEntry
+                                                        .getSavedStateHandle()
+                                                        .set("chosen_seat_index", closestSeatIndex);
                                             }
                                         } catch (Exception e) {
                                             // Handle/ignore if navigation entry not available
@@ -242,10 +250,11 @@ public class ChooserFragment extends Fragment {
                 break;
         }
 
-        return new float[]{x, y};
+        return new float[] {x, y};
     }
 
-    static int getClosestSeatIndex(float touchX, float touchY, float width, float height, int playerCount) {
+    static int getClosestSeatIndex(
+            float touchX, float touchY, float width, float height, int playerCount) {
         int closestIndex = 0;
         double minDistanceSq = Double.MAX_VALUE;
 

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -21,6 +21,7 @@ public class ChooserFragment extends Fragment {
     private ChooserLayoutBinding binding;
     private ChooserViewModel viewModel;
     private final Handler handler = new Handler(Looper.getMainLooper());
+    private Runnable navigateBackRunnable;
     private final Runnable hideInstructionRunnable =
             new Runnable() {
                 @Override
@@ -74,6 +75,33 @@ public class ChooserFragment extends Fragment {
                         return false;
                     }
                 });
+
+        Bundle arguments = getArguments();
+        boolean returnOnSelection = arguments != null && arguments.getBoolean("return_on_selection", false);
+        if (returnOnSelection) {
+            binding.chooserView.setOnSelectionListener(
+                    new com.nicue.onetwo.utils.TouchDisplayView.OnSelectionListener() {
+                        @Override
+                        public void onSelectionMade() {
+                            if (navigateBackRunnable != null) {
+                                handler.removeCallbacks(navigateBackRunnable);
+                            }
+                            navigateBackRunnable =
+                                    new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            if (isAdded()) {
+                                                androidx.navigation.fragment.NavHostFragment.findNavController(ChooserFragment.this)
+                                                        .popBackStack();
+                                            }
+                                        }
+                                    };
+                            handler.postDelayed(
+                                    navigateBackRunnable,
+                                    com.nicue.onetwo.utils.TouchDisplayView.SELECTION_REVEAL_DURATION_MS + 1500L);
+                        }
+                    });
+        }
     }
 
     @Override
@@ -87,6 +115,13 @@ public class ChooserFragment extends Fragment {
     @Override
     public void onDestroyView() {
         handler.removeCallbacks(hideInstructionRunnable);
+        if (navigateBackRunnable != null) {
+            handler.removeCallbacks(navigateBackRunnable);
+            navigateBackRunnable = null;
+        }
+        if (binding != null && binding.chooserView != null) {
+            binding.chooserView.setOnSelectionListener(null);
+        }
         binding = null;
         super.onDestroyView();
     }

--- a/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/chooser/ChooserFragment.java
@@ -77,7 +77,8 @@ public class ChooserFragment extends Fragment {
                 });
 
         Bundle arguments = getArguments();
-        boolean returnOnSelection = arguments != null && arguments.getBoolean("return_on_selection", false);
+        boolean returnOnSelection =
+                arguments != null && arguments.getBoolean("return_on_selection", false);
         if (returnOnSelection) {
             binding.chooserView.setOnSelectionListener(
                     new com.nicue.onetwo.utils.TouchDisplayView.OnSelectionListener() {
@@ -91,14 +92,17 @@ public class ChooserFragment extends Fragment {
                                         @Override
                                         public void run() {
                                             if (isAdded()) {
-                                                androidx.navigation.fragment.NavHostFragment.findNavController(ChooserFragment.this)
+                                                androidx.navigation.fragment.NavHostFragment
+                                                        .findNavController(ChooserFragment.this)
                                                         .popBackStack();
                                             }
                                         }
                                     };
                             handler.postDelayed(
                                     navigateBackRunnable,
-                                    com.nicue.onetwo.utils.TouchDisplayView.SELECTION_REVEAL_DURATION_MS + 1500L);
+                                    com.nicue.onetwo.utils.TouchDisplayView
+                                                    .SELECTION_REVEAL_DURATION_MS
+                                            + 1500L);
                         }
                     });
         }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -17,6 +17,7 @@ public class LifePlayerUiModel {
     private final boolean timerActive;
     private final boolean timerExpired;
     private final boolean passEnabled;
+    private final boolean startTimerVisible;
 
     public LifePlayerUiModel(
             int seatIndex,
@@ -32,7 +33,8 @@ public class LifePlayerUiModel {
             String timerDisplay,
             boolean timerActive,
             boolean timerExpired,
-            boolean passEnabled) {
+            boolean passEnabled,
+            boolean startTimerVisible) {
         this.seatIndex = seatIndex;
         this.lifeTotal = lifeTotal;
         this.rotationDegrees = rotationDegrees;
@@ -47,6 +49,7 @@ public class LifePlayerUiModel {
         this.timerActive = timerActive;
         this.timerExpired = timerExpired;
         this.passEnabled = passEnabled;
+        this.startTimerVisible = startTimerVisible;
     }
 
     public int getSeatIndex() {
@@ -103,5 +106,9 @@ public class LifePlayerUiModel {
 
     public boolean isPassEnabled() {
         return passEnabled;
+    }
+
+    public boolean isStartTimerVisible() {
+        return startTimerVisible;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -139,15 +139,11 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
         menuInflater.inflate(R.menu.life_actions, menu);
         MenuItem newGameItem = menu.findItem(R.id.action_new_game);
-        MenuItem chooserItem = menu.findItem(R.id.action_chooser);
         MtgLifeUiState currentUiState =
                 viewModel != null ? viewModel.getUiState().getValue() : null;
         if (currentUiState != null) {
             if (newGameItem != null) {
                 newGameItem.setVisible(!currentUiState.isShowingSetup());
-            }
-            if (chooserItem != null) {
-                chooserItem.setVisible(!currentUiState.isShowingSetup());
             }
         }
     }
@@ -156,12 +152,6 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
         if (menuItem.getItemId() == R.id.action_new_game) {
             viewModel.resetToSetup();
-            return true;
-        } else if (menuItem.getItemId() == R.id.action_chooser) {
-            Bundle args = new Bundle();
-            args.putBoolean("return_on_selection", true);
-            androidx.navigation.fragment.NavHostFragment.findNavController(this)
-                    .navigate(R.id.nav_chooser, args);
             return true;
         }
         return false;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -99,6 +99,31 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                             }
                         });
 
+        androidx.navigation.NavController navController = null;
+        try {
+            navController = androidx.navigation.fragment.NavHostFragment.findNavController(this);
+        } catch (IllegalStateException e) {
+            // Safe to ignore in unit tests where the fragment is launched outside a NavHost
+        }
+        if (navController != null) {
+            androidx.navigation.NavBackStackEntry currentEntry = navController.getCurrentBackStackEntry();
+            if (currentEntry != null) {
+                androidx.lifecycle.LiveData<Integer> chosenSeatLiveData =
+                        currentEntry.getSavedStateHandle().getLiveData("chosen_seat_index");
+                chosenSeatLiveData.observe(
+                        getViewLifecycleOwner(),
+                        new androidx.lifecycle.Observer<Integer>() {
+                            @Override
+                            public void onChanged(Integer seatIndex) {
+                                if (seatIndex != null) {
+                                    viewModel.setStartingPlayer(seatIndex);
+                                    currentEntry.getSavedStateHandle().remove("chosen_seat_index");
+                                }
+                            }
+                        });
+            }
+        }
+
         setupBinding.startGameButton.setOnClickListener(
                 v -> {
                     Editable playersText = setupBinding.playersInput.getText();

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -285,6 +285,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             cellBinding.commanderDamageGrid.setVisibility(View.GONE);
             cellBinding.timerContainer.setVisibility(View.GONE);
             cellBinding.timerContainer.setOnClickListener(null);
+            cellBinding.btnStartTimer.setVisibility(View.GONE);
+            cellBinding.btnStartTimer.setOnClickListener(null);
             cellBinding.playerCellContainer.setRotation(0f);
             cellBinding.innerPlayerLayout.setRotation(seatIndex % 2 == 0 ? 90f : 270f);
             clearRecentLifeChange(cellBinding.tvRecentLifeChangeNegative);
@@ -387,9 +389,24 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         vibrate(30L);
                         viewModel.passTurn(seatIndex);
                     });
+
+            if (player.isStartTimerVisible()) {
+                cellBinding.btnStartTimer.setVisibility(View.VISIBLE);
+                cellBinding.btnStartTimer.setIconTint(ColorStateList.valueOf(foregroundColor));
+                cellBinding.btnStartTimer.setOnClickListener(
+                        v -> {
+                            vibrate(30L);
+                            viewModel.startTimer();
+                        });
+            } else {
+                cellBinding.btnStartTimer.setVisibility(View.GONE);
+                cellBinding.btnStartTimer.setOnClickListener(null);
+            }
         } else {
             cellBinding.timerContainer.setVisibility(View.GONE);
             cellBinding.timerContainer.setOnClickListener(null);
+            cellBinding.btnStartTimer.setVisibility(View.GONE);
+            cellBinding.btnStartTimer.setOnClickListener(null);
         }
 
         bindCommanderDamageSummary(cellBinding, player, playerCount);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -408,13 +408,20 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                     player.isPassEnabled() ? View.VISIBLE : View.INVISIBLE);
             cellBinding.btnPassTurn.setIconTint(ColorStateList.valueOf(foregroundColor));
 
-            cellBinding.timerContainer.setEnabled(player.isPassEnabled());
+            boolean pillActive = player.isStartTimerVisible() || player.isPassEnabled();
+            cellBinding.timerContainer.setEnabled(pillActive);
             cellBinding.timerContainer.setContentDescription(
-                    getString(R.string.mtg_pass_turn_desc, seatIndex + 1));
+                    player.isStartTimerVisible()
+                            ? getString(R.string.mtg_start_timer_desc, seatIndex + 1)
+                            : getString(R.string.mtg_pass_turn_desc, seatIndex + 1));
             cellBinding.timerContainer.setOnClickListener(
                     v -> {
                         vibrate(30L);
-                        viewModel.passTurn(seatIndex);
+                        if (player.isStartTimerVisible()) {
+                            viewModel.startTimer();
+                        } else {
+                            viewModel.passTurn(seatIndex);
+                        }
                     });
             cellBinding.timerContainer.setOnLongClickListener(
                     v -> {
@@ -423,24 +430,14 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         return true;
                     });
 
-            if (player.isStartTimerVisible()) {
-                cellBinding.btnStartTimer.setVisibility(View.VISIBLE);
-                cellBinding.btnStartTimer.setIconTint(ColorStateList.valueOf(foregroundColor));
-                cellBinding.btnStartTimer.setOnClickListener(
-                        v -> {
-                            vibrate(30L);
-                            viewModel.startTimer();
-                        });
-            } else {
-                cellBinding.btnStartTimer.setVisibility(View.GONE);
-                cellBinding.btnStartTimer.setOnClickListener(null);
-            }
+            cellBinding.btnStartTimer.setVisibility(
+                    player.isStartTimerVisible() ? View.VISIBLE : View.GONE);
+            cellBinding.btnStartTimer.setIconTint(ColorStateList.valueOf(foregroundColor));
         } else {
             cellBinding.timerContainer.setVisibility(View.GONE);
             cellBinding.timerContainer.setOnClickListener(null);
             cellBinding.timerContainer.setOnLongClickListener(null);
             cellBinding.btnStartTimer.setVisibility(View.GONE);
-            cellBinding.btnStartTimer.setOnClickListener(null);
         }
 
         bindCommanderDamageSummary(cellBinding, player, playerCount);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -122,10 +122,16 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
         menuInflater.inflate(R.menu.life_actions, menu);
         MenuItem newGameItem = menu.findItem(R.id.action_new_game);
+        MenuItem chooserItem = menu.findItem(R.id.action_chooser);
         MtgLifeUiState currentUiState =
                 viewModel != null ? viewModel.getUiState().getValue() : null;
-        if (newGameItem != null && currentUiState != null) {
-            newGameItem.setVisible(!currentUiState.isShowingSetup());
+        if (currentUiState != null) {
+            if (newGameItem != null) {
+                newGameItem.setVisible(!currentUiState.isShowingSetup());
+            }
+            if (chooserItem != null) {
+                chooserItem.setVisible(!currentUiState.isShowingSetup());
+            }
         }
     }
 
@@ -133,6 +139,12 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
         if (menuItem.getItemId() == R.id.action_new_game) {
             viewModel.resetToSetup();
+            return true;
+        } else if (menuItem.getItemId() == R.id.action_chooser) {
+            Bundle args = new Bundle();
+            args.putBoolean("return_on_selection", true);
+            androidx.navigation.fragment.NavHostFragment.findNavController(this)
+                    .navigate(R.id.nav_chooser, args);
             return true;
         }
         return false;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -123,6 +123,10 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                             playersStr, lifeStr, commanderEnabled, turnTimerEnabled)) {
                         Bundle args = new Bundle();
                         args.putBoolean("return_on_selection", true);
+                        MtgLifeUiState state = viewModel.getUiState().getValue();
+                        if (state != null) {
+                            args.putInt("player_count", state.getPlayerCount());
+                        }
                         androidx.navigation.fragment.NavHostFragment.findNavController(this)
                                 .navigate(R.id.nav_chooser, args);
                     }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -458,6 +458,14 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.commanderDamageGrid.setVisibility(View.VISIBLE);
         cellBinding.commanderDamageGrid.removeAllViews();
 
+        GradientDrawable pillBackground = new GradientDrawable();
+        pillBackground.setCornerRadius(dpToPx(12));
+        pillBackground.setColor(0x20FFFFFF);
+        pillBackground.setStroke(dpToPx(1), 0x30FFFFFF);
+        cellBinding.commanderDamageGrid.setBackground(pillBackground);
+        int pillPadding = dpToPx(4);
+        cellBinding.commanderDamageGrid.setPadding(pillPadding, pillPadding, pillPadding, pillPadding);
+
         int rows = getCommanderGridRowCount(totalPlayers);
         int cols = getCommanderGridColumnCount(totalPlayers);
         List<CommanderDamageUiModel> damages = player.getCommanderDamages();
@@ -492,6 +500,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     }
 
     private View createCommanderSummaryCell(CommanderDamageUiModel damage, int defenderSeatIndex) {
+
         TextView summaryCell = new TextView(requireContext());
         summaryCell.setGravity(Gravity.CENTER);
         summaryCell.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -285,6 +285,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             cellBinding.commanderDamageGrid.setVisibility(View.GONE);
             cellBinding.timerContainer.setVisibility(View.GONE);
             cellBinding.timerContainer.setOnClickListener(null);
+            cellBinding.timerContainer.setOnLongClickListener(null);
             cellBinding.btnStartTimer.setVisibility(View.GONE);
             cellBinding.btnStartTimer.setOnClickListener(null);
             cellBinding.playerCellContainer.setRotation(0f);
@@ -389,6 +390,12 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                         vibrate(30L);
                         viewModel.passTurn(seatIndex);
                     });
+            cellBinding.timerContainer.setOnLongClickListener(
+                    v -> {
+                        vibrate(50L);
+                        viewModel.togglePlayPause();
+                        return true;
+                    });
 
             if (player.isStartTimerVisible()) {
                 cellBinding.btnStartTimer.setVisibility(View.VISIBLE);
@@ -405,6 +412,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         } else {
             cellBinding.timerContainer.setVisibility(View.GONE);
             cellBinding.timerContainer.setOnClickListener(null);
+            cellBinding.timerContainer.setOnLongClickListener(null);
             cellBinding.btnStartTimer.setVisibility(View.GONE);
             cellBinding.btnStartTimer.setOnClickListener(null);
         }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -111,6 +111,23 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                             playersStr, lifeStr, commanderEnabled, turnTimerEnabled);
                 });
 
+        setupBinding.chooseAndStartButton.setOnClickListener(
+                v -> {
+                    Editable playersText = setupBinding.playersInput.getText();
+                    Editable lifeText = setupBinding.lifeInput.getText();
+                    String playersStr = playersText != null ? playersText.toString() : "";
+                    String lifeStr = lifeText != null ? lifeText.toString() : "";
+                    boolean commanderEnabled = setupBinding.commanderDamageSwitch.isChecked();
+                    boolean turnTimerEnabled = setupBinding.turnTimerSwitch.isChecked();
+                    if (viewModel.validateAndStartGame(
+                            playersStr, lifeStr, commanderEnabled, turnTimerEnabled)) {
+                        Bundle args = new Bundle();
+                        args.putBoolean("return_on_selection", true);
+                        androidx.navigation.fragment.NavHostFragment.findNavController(this)
+                                .navigate(R.id.nav_chooser, args);
+                    }
+                });
+
         binding.setupOverlay.setOnClickListener(v -> viewModel.dismissSetup());
         setupBinding.getRoot().setOnClickListener(v -> {});
 

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -106,7 +106,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             // Safe to ignore in unit tests where the fragment is launched outside a NavHost
         }
         if (navController != null) {
-            androidx.navigation.NavBackStackEntry currentEntry = navController.getCurrentBackStackEntry();
+            androidx.navigation.NavBackStackEntry currentEntry =
+                    navController.getCurrentBackStackEntry();
             if (currentEntry != null) {
                 androidx.lifecycle.LiveData<Integer> chosenSeatLiveData =
                         currentEntry.getSavedStateHandle().getLiveData("chosen_seat_index");
@@ -464,7 +465,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         pillBackground.setStroke(dpToPx(1), 0x30FFFFFF);
         cellBinding.commanderDamageGrid.setBackground(pillBackground);
         int pillPadding = dpToPx(4);
-        cellBinding.commanderDamageGrid.setPadding(pillPadding, pillPadding, pillPadding, pillPadding);
+        cellBinding.commanderDamageGrid.setPadding(
+                pillPadding, pillPadding, pillPadding, pillPadding);
 
         int rows = getCommanderGridRowCount(totalPlayers);
         int cols = getCommanderGridColumnCount(totalPlayers);

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -342,7 +342,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         int foregroundColor =
                 player.isTimerExpired()
                         ? ContextCompat.getColor(requireContext(), R.color.mtg_expired_foreground)
-                        : getForegroundColor(backgroundColor);
+                        : ContextCompat.getColor(requireContext(), player.getForegroundColorRes());
         int seatIndex = player.getSeatIndex();
 
         TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -142,17 +142,17 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_TURN_TIMER_LAST_TICK_TIME_MS, timeMs);
     }
 
-    public void validateAndStartGame(String playersStr, String lifeStr) {
-        validateAndStartGame(
+    public boolean validateAndStartGame(String playersStr, String lifeStr) {
+        return validateAndStartGame(
                 playersStr, lifeStr, getCommanderDamageEnabled(), getTurnTimerEnabled());
     }
 
-    public void validateAndStartGame(
+    public boolean validateAndStartGame(
             String playersStr, String lifeStr, boolean commanderDamageEnabled) {
-        validateAndStartGame(playersStr, lifeStr, commanderDamageEnabled, getTurnTimerEnabled());
+        return validateAndStartGame(playersStr, lifeStr, commanderDamageEnabled, getTurnTimerEnabled());
     }
 
-    public void validateAndStartGame(
+    public boolean validateAndStartGame(
             String playersStr,
             String lifeStr,
             boolean commanderDamageEnabled,
@@ -170,7 +170,7 @@ public class MtgLifeViewModel extends ViewModel {
         if (parsedPlayerCount == null || parsedStartingLife == null) {
             savedStateHandle.set(KEY_SHOWING_SETUP, true);
             updateUiState();
-            return;
+            return false;
         }
 
         savedStateHandle.set(KEY_PLAYER_COUNT, parsedPlayerCount);
@@ -215,6 +215,7 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_SHOWING_SETUP, false);
 
         updateUiState();
+        return true;
     }
 
     public void incrementLife(int seatIndex) {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -179,7 +179,8 @@ public class MtgLifeViewModel extends ViewModel {
 
     public boolean validateAndStartGame(
             String playersStr, String lifeStr, boolean commanderDamageEnabled) {
-        return validateAndStartGame(playersStr, lifeStr, commanderDamageEnabled, getTurnTimerEnabled());
+        return validateAndStartGame(
+                playersStr, lifeStr, commanderDamageEnabled, getTurnTimerEnabled());
     }
 
     public boolean validateAndStartGame(
@@ -828,7 +829,8 @@ public class MtgLifeViewModel extends ViewModel {
         } else if (val instanceof String) {
             try {
                 return Integer.parseInt((String) val);
-            } catch (NumberFormatException ignored) {}
+            } catch (NumberFormatException ignored) {
+            }
         }
         return null;
     }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -91,6 +91,11 @@ public class MtgLifeViewModel extends ViewModel {
 
     public void setStartingPlayer(Integer seatIndex) {
         savedStateHandle.set(KEY_STARTING_PLAYER, seatIndex);
+        if (seatIndex != null) {
+            timerEngine.setRunningIndex(seatIndex);
+            savedStateHandle.set(KEY_TURN_TIMER_ACTIVE_SEAT_INDEX, seatIndex);
+        }
+        updateUiState();
     }
 
     public Integer getStartingPlayer() {
@@ -212,6 +217,8 @@ public class MtgLifeViewModel extends ViewModel {
                 KEY_COMMANDER_DAMAGE_MATRIX, createCommanderDamageMatrix(parsedPlayerCount));
 
         savedStateHandle.set(KEY_TURN_TIMER_ENABLED, turnTimerEnabled);
+        Integer startingPlayer = getStartingPlayer();
+        int initialActiveSeat = startingPlayer == null ? 0 : startingPlayer;
         if (turnTimerEnabled) {
             long duration = getTurnTimerDurationMs();
             ArrayList<Long> initialRemaining = new ArrayList<>();
@@ -219,7 +226,7 @@ public class MtgLifeViewModel extends ViewModel {
                 initialRemaining.add(duration);
             }
             timerEngine.setRemainingTimes(initialRemaining);
-            timerEngine.setRunningIndex(0);
+            timerEngine.setRunningIndex(initialActiveSeat);
             timerEngine.setPaused(true);
             timerEngine.setLastTickTimeMs(0L);
             savedStateHandle.set(KEY_TURN_TIMER_FINISHED, duration <= 0L);
@@ -227,11 +234,11 @@ public class MtgLifeViewModel extends ViewModel {
         } else {
             timerScheduler.stop();
             timerEngine.setRemainingTimes(new ArrayList<>());
-            timerEngine.setRunningIndex(0);
+            timerEngine.setRunningIndex(initialActiveSeat);
             timerEngine.setPaused(true);
             timerEngine.setLastTickTimeMs(0L);
             savedStateHandle.set(KEY_TURN_TIMER_REMAINING_TIMES, null);
-            savedStateHandle.set(KEY_TURN_TIMER_ACTIVE_SEAT_INDEX, 0);
+            savedStateHandle.set(KEY_TURN_TIMER_ACTIVE_SEAT_INDEX, initialActiveSeat);
             savedStateHandle.set(KEY_TURN_TIMER_PAUSED, true);
             savedStateHandle.set(KEY_TURN_TIMER_FINISHED, false);
             savedStateHandle.set(KEY_TURN_TIMER_LAST_TICK_TIME_MS, 0L);
@@ -804,13 +811,13 @@ public class MtgLifeViewModel extends ViewModel {
             Object val = savedStateHandle.get("starting_player");
             Integer parsed = parseInteger(val);
             if (parsed != null) {
-                savedStateHandle.set(KEY_STARTING_PLAYER, parsed);
+                setStartingPlayer(parsed);
             }
         } else if (savedStateHandle.contains(KEY_STARTING_PLAYER)) {
             Object val = savedStateHandle.get(KEY_STARTING_PLAYER);
             Integer parsed = parseInteger(val);
             if (parsed != null) {
-                savedStateHandle.set(KEY_STARTING_PLAYER, parsed);
+                setStartingPlayer(parsed);
             }
         }
     }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -101,6 +101,17 @@ public class MtgLifeViewModel extends ViewModel {
         startTimer(nowProvider.now());
     }
 
+    public void togglePlayPause() {
+        if (!getTurnTimerEnabled() || getTurnTimerFinished()) {
+            return;
+        }
+        if (getTurnTimerPaused()) {
+            startTimer();
+        } else {
+            pauseTimer();
+        }
+    }
+
     public boolean getTurnTimerEnabled() {
         Boolean enabled = savedStateHandle.get(KEY_TURN_TIMER_ENABLED);
         return enabled != null && enabled;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -24,6 +24,7 @@ public class MtgLifeViewModel extends ViewModel {
     private static final String KEY_LIFE_ERROR_RES_ID = "lifeErrorResId";
     private static final String KEY_COMMANDER_DAMAGE_ENABLED = "commanderDamageEnabled";
     private static final String KEY_COMMANDER_DAMAGE_MATRIX = "commanderDamageMatrix";
+    private static final String KEY_STARTING_PLAYER = "startingPlayer";
 
     private static final String KEY_TURN_TIMER_ENABLED = "turnTimerEnabled";
     private static final String KEY_TURN_TIMER_DURATION_MS = "turnTimerDurationMs";
@@ -80,11 +81,20 @@ public class MtgLifeViewModel extends ViewModel {
             timerScheduler.start(this::handleTick);
         }
 
+        initStartingPlayer();
         updateUiState();
     }
 
     public LiveData<MtgLifeUiState> getUiState() {
         return uiState;
+    }
+
+    public void setStartingPlayer(Integer seatIndex) {
+        savedStateHandle.set(KEY_STARTING_PLAYER, seatIndex);
+    }
+
+    public Integer getStartingPlayer() {
+        return savedStateHandle.get(KEY_STARTING_PLAYER);
     }
 
     public boolean getTurnTimerEnabled() {
@@ -769,5 +779,32 @@ public class MtgLifeViewModel extends ViewModel {
         savedStateHandle.set(KEY_TURN_TIMER_FINISHED, true);
         persistTurnTimerState();
         updateUiState();
+    }
+
+    private void initStartingPlayer() {
+        if (savedStateHandle.contains("starting_player")) {
+            Object val = savedStateHandle.get("starting_player");
+            Integer parsed = parseInteger(val);
+            if (parsed != null) {
+                savedStateHandle.set(KEY_STARTING_PLAYER, parsed);
+            }
+        } else if (savedStateHandle.contains(KEY_STARTING_PLAYER)) {
+            Object val = savedStateHandle.get(KEY_STARTING_PLAYER);
+            Integer parsed = parseInteger(val);
+            if (parsed != null) {
+                savedStateHandle.set(KEY_STARTING_PLAYER, parsed);
+            }
+        }
+    }
+
+    private Integer parseInteger(Object val) {
+        if (val instanceof Integer) {
+            return (Integer) val;
+        } else if (val instanceof String) {
+            try {
+                return Integer.parseInt((String) val);
+            } catch (NumberFormatException ignored) {}
+        }
+        return null;
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -97,6 +97,10 @@ public class MtgLifeViewModel extends ViewModel {
         return savedStateHandle.get(KEY_STARTING_PLAYER);
     }
 
+    public void startTimer() {
+        startTimer(nowProvider.now());
+    }
+
     public boolean getTurnTimerEnabled() {
         Boolean enabled = savedStateHandle.get(KEY_TURN_TIMER_ENABLED);
         return enabled != null && enabled;
@@ -704,6 +708,7 @@ public class MtgLifeViewModel extends ViewModel {
                 boolean timerActive = false;
                 boolean timerExpired = false;
                 boolean passEnabled = false;
+                boolean startTimerVisible = false;
 
                 if (timerVisible) {
                     long remainingTime = remainingTimes.get(seatIndex);
@@ -711,6 +716,7 @@ public class MtgLifeViewModel extends ViewModel {
                     timerActive = seatIndex == activeSeatIndex;
                     timerExpired = remainingTime <= 0L;
                     passEnabled = timerActive && !turnTimerFinished && remainingTime > 0L;
+                    startTimerVisible = timerActive && turnTimerPaused && !turnTimerFinished;
                 }
 
                 players.add(
@@ -729,7 +735,8 @@ public class MtgLifeViewModel extends ViewModel {
                                 timerDisplay,
                                 timerActive,
                                 timerExpired,
-                                passEnabled));
+                                passEnabled,
+                                startTimerVisible));
             }
         }
 

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -618,4 +618,12 @@ public class TouchDisplayView extends View {
     public boolean getChoosingOrder() {
         return choosingOrder;
     }
+
+    public float getSelectionRevealCenterX() {
+        return selectionRevealCenterX;
+    }
+
+    public float getSelectionRevealCenterY() {
+        return selectionRevealCenterY;
+    }
 }

--- a/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
+++ b/app/src/main/java/com/nicue/onetwo/utils/TouchDisplayView.java
@@ -25,7 +25,7 @@ public class TouchDisplayView extends View {
     private boolean alreadyChosen = false;
     private boolean choosingOrder = false;
     // private int fingers = 0;
-    private static final long SELECTION_REVEAL_DURATION_MS = 650L;
+    public static final long SELECTION_REVEAL_DURATION_MS = 650L;
     private static final int SELECTED_TOUCH_ALPHA = 255;
     private static final int DIMMED_TOUCH_ALPHA = 105;
     private static final int TOUCH_HALO_ALPHA = 125;
@@ -57,6 +57,16 @@ public class TouchDisplayView extends View {
         0xFF7D5260 // M3 Maroon
     };
 
+    public interface OnSelectionListener {
+        void onSelectionMade();
+    }
+
+    private OnSelectionListener mSelectionListener;
+
+    public void setOnSelectionListener(OnSelectionListener listener) {
+        this.mSelectionListener = listener;
+    }
+
     // A Handler to check if all fingers have been pressed down for x time
     private final Handler handler = new Handler();
     private final Runnable runnable =
@@ -81,6 +91,10 @@ public class TouchDisplayView extends View {
                 long[] pattern = {0, 20, 10, 50};
                 v.vibrate(pattern, -1);
                 invalidate();
+
+                if (mSelectionListener != null) {
+                    mSelectionListener.onSelectionMade();
+                }
             }
         }
     }

--- a/app/src/main/res/drawable/ic_play_arrow_24.xml
+++ b/app/src/main/res/drawable/ic_play_arrow_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -91,6 +91,30 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_start_timer"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:insetTop="0dp"
+            android:insetBottom="0dp"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:elevation="4dp"
+            android:visibility="gone"
+            app:icon="@drawable/ic_play_arrow_24"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp"
+            app:iconSize="16dp"
+            app:layout_constraintStart_toEndOf="@id/timer_container"
+            app:layout_constraintTop_toTopOf="@id/timer_container"
+            app:layout_constraintBottom_toBottomOf="@id/timer_container"
+            android:layout_marginStart="8dp" />
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_minus"
             style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="56dp"

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -41,13 +41,25 @@
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="4dp">
 
-            <View
-                android:id="@+id/timer_left_spacer"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_start_timer"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:minHeight="0dp"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
                 android:clickable="false"
                 android:focusable="false"
                 android:importantForAccessibility="no"
+                app:icon="@drawable/ic_play_arrow_24"
+                app:iconGravity="textStart"
+                app:iconPadding="0dp"
+                app:iconSize="16dp"
+                app:iconTint="?attr/colorOnSurface"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent" />
@@ -65,7 +77,7 @@
                 android:layout_marginEnd="6dp"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/timer_left_spacer"
+                app:layout_constraintStart_toEndOf="@id/btn_start_timer"
                 app:layout_constraintEnd_toStartOf="@id/btn_pass_turn" />
 
             <com.google.android.material.button.MaterialButton
@@ -90,29 +102,7 @@
                 app:layout_constraintBottom_toBottomOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btn_start_timer"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:insetTop="0dp"
-            android:insetBottom="0dp"
-            android:minHeight="0dp"
-            android:minWidth="0dp"
-            android:paddingStart="0dp"
-            android:paddingEnd="0dp"
-            android:clickable="true"
-            android:focusable="true"
-            android:elevation="4dp"
-            android:visibility="gone"
-            app:icon="@drawable/ic_play_arrow_24"
-            app:iconGravity="textStart"
-            app:iconPadding="0dp"
-            app:iconSize="16dp"
-            app:layout_constraintStart_toEndOf="@id/timer_container"
-            app:layout_constraintTop_toTopOf="@id/timer_container"
-            app:layout_constraintBottom_toBottomOf="@id/timer_container"
-            android:layout_marginStart="8dp" />
+
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_minus"

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -27,19 +27,36 @@
             android:id="@+id/timer_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:minWidth="108dp"
             android:elevation="4dp"
             android:visibility="gone"
             android:background="@drawable/bg_timer_pill"
-            android:paddingStart="8dp"
-            android:paddingEnd="8dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
             android:clickable="true"
             android:focusable="true"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="4dp">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_turn_timer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                android:textColor="?attr/colorOnSurface"
+                android:clickable="false"
+                android:focusable="false"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_start_timer"
@@ -63,22 +80,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent" />
-
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/tv_turn_timer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="14sp"
-                android:textStyle="bold"
-                android:textColor="?attr/colorOnSurface"
-                android:clickable="false"
-                android:focusable="false"
-                android:layout_marginStart="6dp"
-                android:layout_marginEnd="6dp"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/btn_start_timer"
-                app:layout_constraintEnd_toStartOf="@id/btn_pass_turn" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_pass_turn"

--- a/app/src/main/res/layout/life_setup_content.xml
+++ b/app/src/main/res/layout/life_setup_content.xml
@@ -198,6 +198,16 @@
             android:textColor="?attr/colorOnPrimary"
             android:text="@string/mtg_setup_start" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/choose_and_start_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:minHeight="56dp"
+            style="@style/Widget.Material3.Button.TonalButton"
+            app:cornerRadius="@dimen/shape_corner_soft"
+            android:text="@string/mtg_setup_choose_and_start" />
+
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/life_actions.xml
+++ b/app/src/main/res/menu/life_actions.xml
@@ -5,4 +5,9 @@
         android:id="@+id/action_new_game"
         android:title="@string/mtg_setup_title"
         app:showAsAction="always|withText" />
+    <item
+        android:id="@+id/action_chooser"
+        android:icon="@drawable/fingerprint"
+        android:title="@string/menu_chooser"
+        app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/menu/life_actions.xml
+++ b/app/src/main/res/menu/life_actions.xml
@@ -5,9 +5,4 @@
         android:id="@+id/action_new_game"
         android:title="@string/mtg_setup_title"
         app:showAsAction="always|withText" />
-    <item
-        android:id="@+id/action_chooser"
-        android:icon="@drawable/fingerprint"
-        android:title="@string/menu_chooser"
-        app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -85,6 +85,7 @@
     <string name="mtg_setup_time">Tiempo</string>
     <string name="mtg_pass_turn">Pasar</string>
     <string name="mtg_pass_turn_desc">Pasar el turno del jugador %1$d al siguiente jugador</string>
+    <string name="mtg_start_timer_desc">Iniciar temporizador para el jugador %1$d</string>
     <string name="mtg_player_timer_desc">Tiempo restante del jugador %1$d: %2$s</string>
     <string name="mtg_setup_choose_and_start">Elegir 1º y empezar</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,4 +86,5 @@
     <string name="mtg_pass_turn">Pasar</string>
     <string name="mtg_pass_turn_desc">Pasar el turno del jugador %1$d al siguiente jugador</string>
     <string name="mtg_player_timer_desc">Tiempo restante del jugador %1$d: %2$s</string>
+    <string name="mtg_setup_choose_and_start">Elegir 1º y empezar</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -63,6 +63,7 @@
     <string name="mtg_setup_time">Temps</string>
     <string name="mtg_pass_turn">Passer</string>
     <string name="mtg_pass_turn_desc">Passer le tour du joueur %1$d au joueur suivant</string>
+    <string name="mtg_start_timer_desc">Démarrer le minuteur pour le joueur %1$d</string>
     <string name="mtg_player_timer_desc">Temps restant du joueur %1$d : %2$s</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,6 +63,7 @@
     <string name="mtg_setup_time">時間</string>
     <string name="mtg_pass_turn">パス</string>
     <string name="mtg_pass_turn_desc">プレイヤー%1$dのターンを次のプレイヤーに渡す</string>
+    <string name="mtg_start_timer_desc">プレイヤー%1$dのタイマーを開始する</string>
     <string name="mtg_player_timer_desc">プレイヤー%1$dの残り時間: %2$s</string>
 
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -54,7 +54,7 @@
     <color name="lifeCounterPlayer1">#1C5F8C</color>
     <color name="lifeCounterOnPlayer1">#FFFFFFFF</color>
     <color name="lifeCounterPlayer2">#F3BB21</color>
-    <color name="lifeCounterOnPlayer2">#FF000000</color>
+    <color name="lifeCounterOnPlayer2">#FFFFFFFF</color>
     <color name="lifeCounterPlayer3">#BD2430</color>
     <color name="lifeCounterOnPlayer3">#FFFFFFFF</color>
     <color name="lifeCounterPlayer4">#F65B59</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -59,7 +59,7 @@
     <color name="lifeCounterPlayer1">#18527A</color>
     <color name="lifeCounterOnPlayer1">#FFFFFFFF</color>
     <color name="lifeCounterPlayer2">#F65B59</color>
-    <color name="lifeCounterOnPlayer2">#FF000000</color>
+    <color name="lifeCounterOnPlayer2">#FFFFFFFF</color>
     <color name="lifeCounterPlayer3">#BD2430</color>
     <color name="lifeCounterOnPlayer3">#FFFFFFFF</color>
     <color name="lifeCounterPlayer4">#FF9800</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,4 +99,5 @@
     <string name="mtg_pass_turn">Pass</string>
     <string name="mtg_pass_turn_desc">Pass turn from player %1$d to next player</string>
     <string name="mtg_player_timer_desc">Player %1$d remaining time: %2$s</string>
+    <string name="mtg_setup_choose_and_start">Choose 1st &amp; Start</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="mtg_setup_time">Time</string>
     <string name="mtg_pass_turn">Pass</string>
     <string name="mtg_pass_turn_desc">Pass turn from player %1$d to next player</string>
+    <string name="mtg_start_timer_desc">Start timer for player %1$d</string>
     <string name="mtg_player_timer_desc">Player %1$d remaining time: %2$s</string>
     <string name="mtg_setup_choose_and_start">Choose 1st &amp; Start</string>
 </resources>

--- a/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserFragmentTest.java
@@ -43,10 +43,15 @@ public class ChooserFragmentTest {
                         Bundle args = new Bundle();
                         args.putBoolean("return_on_selection", true);
                         navController.navigate(R.id.nav_chooser, args);
-                        assertEquals(R.id.nav_chooser, navController.getCurrentDestination().getId());
+                        activity.getSupportFragmentManager().executePendingTransactions();
+                        fragment.getChildFragmentManager().executePendingTransactions();
+                        assertEquals(
+                                R.id.nav_chooser, navController.getCurrentDestination().getId());
 
                         // Retrieve the fragment view and invoke TouchDisplayView's callback
-                        Fragment currentFragment = fragment.getChildFragmentManager().getFragments().get(0);
+                        Fragment currentFragment =
+                                fragment.getChildFragmentManager().getPrimaryNavigationFragment();
+                        assertNotNull(currentFragment);
                         assertTrue(currentFragment instanceof ChooserFragment);
                         ChooserFragment chooserFragment = (ChooserFragment) currentFragment;
 
@@ -56,7 +61,8 @@ public class ChooserFragmentTest {
                         assertNotNull(chooserView);
 
                         // Add a touch so mTouches is not empty
-                        MotionEvent eventDown = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 100f, 100f, 0);
+                        MotionEvent eventDown =
+                                MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 100f, 100f, 0);
                         chooserView.dispatchTouchEvent(eventDown);
                         eventDown.recycle();
 
@@ -75,10 +81,13 @@ public class ChooserFragmentTest {
 
                         // Idle main looper for delay
                         Shadows.shadowOf(Looper.getMainLooper())
-                                .idleFor(TouchDisplayView.SELECTION_REVEAL_DURATION_MS + 1500L, TimeUnit.MILLISECONDS);
+                                .idleFor(
+                                        TouchDisplayView.SELECTION_REVEAL_DURATION_MS + 1500L,
+                                        TimeUnit.MILLISECONDS);
 
                         // Assert we popped back to nav_mtg_life
-                        assertEquals(R.id.nav_mtg_life, navController.getCurrentDestination().getId());
+                        assertEquals(
+                                R.id.nav_mtg_life, navController.getCurrentDestination().getId());
                     });
         }
     }

--- a/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserFragmentTest.java
@@ -91,4 +91,23 @@ public class ChooserFragmentTest {
                     });
         }
     }
+
+    @Test
+    public void testClosestSeatIndexCalculation() {
+        float width = 400f;
+        float height = 400f;
+
+        // Player count 4: Top-Left (0), Top-Right (1), Bottom-Left (2), Bottom-Right (3)
+        assertEquals(0, ChooserFragment.getClosestSeatIndex(50f, 50f, width, height, 4));
+        assertEquals(0, ChooserFragment.getClosestSeatIndex(150f, 150f, width, height, 4));
+        assertEquals(1, ChooserFragment.getClosestSeatIndex(350f, 50f, width, height, 4));
+        assertEquals(1, ChooserFragment.getClosestSeatIndex(250f, 150f, width, height, 4));
+        assertEquals(2, ChooserFragment.getClosestSeatIndex(50f, 350f, width, height, 4));
+        assertEquals(3, ChooserFragment.getClosestSeatIndex(350f, 350f, width, height, 4));
+
+        // Player count 3: player_1 is bottom (0), player_2 top left (1), player_3 top right (2)
+        assertEquals(0, ChooserFragment.getClosestSeatIndex(200f, 350f, width, height, 3));
+        assertEquals(1, ChooserFragment.getClosestSeatIndex(50f, 50f, width, height, 3));
+        assertEquals(2, ChooserFragment.getClosestSeatIndex(350f, 50f, width, height, 3));
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/chooser/ChooserFragmentTest.java
@@ -1,0 +1,85 @@
+package com.nicue.onetwo.ui.chooser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Bundle;
+import android.os.Looper;
+import android.view.MotionEvent;
+import android.view.View;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
+import androidx.test.core.app.ActivityScenario;
+import com.nicue.onetwo.MainActivity;
+import com.nicue.onetwo.R;
+import com.nicue.onetwo.utils.TouchDisplayView;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class ChooserFragmentTest {
+
+    @Test
+    public void testChooserFragmentReturnOnSelectionBehavior() {
+        try (ActivityScenario<MainActivity> scenario =
+                ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(
+                    activity -> {
+                        Fragment fragment =
+                                activity.getSupportFragmentManager()
+                                        .findFragmentById(R.id.nav_host_fragment);
+                        assertNotNull(fragment);
+                        NavController navController =
+                                ((NavHostFragment) fragment).getNavController();
+
+                        // Navigate to Chooser with argument
+                        Bundle args = new Bundle();
+                        args.putBoolean("return_on_selection", true);
+                        navController.navigate(R.id.nav_chooser, args);
+                        assertEquals(R.id.nav_chooser, navController.getCurrentDestination().getId());
+
+                        // Retrieve the fragment view and invoke TouchDisplayView's callback
+                        Fragment currentFragment = fragment.getChildFragmentManager().getFragments().get(0);
+                        assertTrue(currentFragment instanceof ChooserFragment);
+                        ChooserFragment chooserFragment = (ChooserFragment) currentFragment;
+
+                        View view = chooserFragment.getView();
+                        assertNotNull(view);
+                        TouchDisplayView chooserView = view.findViewById(R.id.chooser_view);
+                        assertNotNull(chooserView);
+
+                        // Add a touch so mTouches is not empty
+                        MotionEvent eventDown = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 100f, 100f, 0);
+                        chooserView.dispatchTouchEvent(eventDown);
+                        eventDown.recycle();
+
+                        // Set fingersDown = true via reflection
+                        try {
+                            java.lang.reflect.Field fingersDownField =
+                                    TouchDisplayView.class.getDeclaredField("fingersDown");
+                            fingersDownField.setAccessible(true);
+                            fingersDownField.set(chooserView, true);
+                        } catch (Exception e) {
+                            throw new AssertionError(e);
+                        }
+
+                        // Trigger choice selection
+                        chooserView.checkGlobalVariable();
+
+                        // Idle main looper for delay
+                        Shadows.shadowOf(Looper.getMainLooper())
+                                .idleFor(TouchDisplayView.SELECTION_REVEAL_DURATION_MS + 1500L, TimeUnit.MILLISECONDS);
+
+                        // Assert we popped back to nav_mtg_life
+                        assertEquals(R.id.nav_mtg_life, navController.getCurrentDestination().getId());
+                    });
+        }
+    }
+}

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -7,13 +7,11 @@ import static org.junit.Assert.assertTrue;
 import android.app.Dialog;
 import android.graphics.Rect;
 import android.os.Looper;
-import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import androidx.appcompat.view.menu.MenuBuilder;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.testing.FragmentScenario;
@@ -727,7 +725,6 @@ public class MtgLifeFragmentTest {
         }
     }
 
-
     @Test
     public void testChooseAndStartButtonNavigatesToChooser() {
         try (ActivityScenario<MainActivity> scenario =
@@ -763,7 +760,8 @@ public class MtgLifeFragmentTest {
                         lifeInput.setText("40");
 
                         // Press Choose 1st & Start button
-                        Button chooseAndStartButton = view.findViewById(R.id.choose_and_start_button);
+                        Button chooseAndStartButton =
+                                view.findViewById(R.id.choose_and_start_button);
                         assertNotNull(chooseAndStartButton);
                         chooseAndStartButton.performClick();
 

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -717,6 +717,35 @@ public class MtgLifeFragmentTest {
                         assertNotNull(timerContainer);
                         assertEquals(View.GONE, timerContainer.getVisibility());
                     });
+    @Test
+    public void testChooserMenuItemNavigatesToChooser() {
+        try (androidx.test.core.app.ActivityScenario<com.nicue.onetwo.MainActivity> scenario =
+                androidx.test.core.app.ActivityScenario.launch(com.nicue.onetwo.MainActivity.class)) {
+            scenario.onActivity(
+                    activity -> {
+                        androidx.fragment.app.Fragment fragment =
+                                activity.getSupportFragmentManager()
+                                        .findFragmentById(R.id.nav_host_fragment);
+                        assertNotNull(fragment);
+                        androidx.navigation.NavController navController =
+                                ((androidx.navigation.fragment.NavHostFragment) fragment).getNavController();
+
+                        // Currently at start destination (nav_mtg_life)
+                        assertEquals(R.id.nav_mtg_life, navController.getCurrentDestination().getId());
+
+                        // Find the visible Fragment
+                        androidx.fragment.app.Fragment currentFragment = fragment.getChildFragmentManager().getFragments().get(0);
+                        assertTrue(currentFragment instanceof MtgLifeFragment);
+                        MtgLifeFragment mtgLifeFragment = (MtgLifeFragment) currentFragment;
+
+                        // Click the chooser menu item
+                        org.robolectric.fakes.RoboMenuItem chooserMenuItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_chooser);
+                        mtgLifeFragment.onMenuItemSelected(chooserMenuItem);
+
+                        // Assert we navigated to nav_chooser
+                        assertEquals(R.id.nav_chooser, navController.getCurrentDestination().getId());
+                    });
         }
     }
 

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -727,47 +727,6 @@ public class MtgLifeFragmentTest {
         }
     }
 
-    @Test
-    @SuppressWarnings("RestrictedApi")
-    public void testChooserMenuItemNavigatesToChooser() {
-        try (ActivityScenario<MainActivity> scenario =
-                ActivityScenario.launch(MainActivity.class)) {
-            scenario.onActivity(
-                    activity -> {
-                        Fragment fragment =
-                                activity.getSupportFragmentManager()
-                                        .findFragmentById(R.id.nav_host_fragment);
-                        assertNotNull(fragment);
-                        NavController navController =
-                                ((NavHostFragment) fragment).getNavController();
-
-                        // Currently at start destination (nav_mtg_life)
-                        assertEquals(
-                                R.id.nav_mtg_life, navController.getCurrentDestination().getId());
-
-                        Fragment currentFragment =
-                                fragment.getChildFragmentManager().getFragments().get(0);
-                        assertTrue(currentFragment instanceof MtgLifeFragment);
-                        MtgLifeFragment mtgLifeFragment = (MtgLifeFragment) currentFragment;
-
-                        View view = mtgLifeFragment.requireView();
-                        View setupContent = view.findViewById(R.id.setup_content);
-                        assertNotNull(setupContent);
-                        assertEquals(View.GONE, setupContent.getVisibility());
-
-                        MenuBuilder menu = new MenuBuilder(activity);
-                        mtgLifeFragment.onCreateMenu(menu, activity.getMenuInflater());
-                        MenuItem chooserMenuItem = menu.findItem(R.id.action_chooser);
-                        assertNotNull(chooserMenuItem);
-                        assertTrue(chooserMenuItem.isVisible());
-
-                        mtgLifeFragment.onMenuItemSelected(chooserMenuItem);
-
-                        assertEquals(
-                                R.id.nav_chooser, navController.getCurrentDestination().getId());
-                    });
-        }
-    }
 
     @Test
     public void testChooseAndStartButtonNavigatesToChooser() {

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -7,13 +7,20 @@ import static org.junit.Assert.assertTrue;
 import android.app.Dialog;
 import android.graphics.Rect;
 import android.os.Looper;
+import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+import androidx.appcompat.view.menu.MenuBuilder;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.testing.FragmentScenario;
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
+import androidx.test.core.app.ActivityScenario;
+import com.nicue.onetwo.MainActivity;
 import com.nicue.onetwo.R;
 import com.nicue.onetwo.databinding.LifePlayerCellBinding;
 import java.util.concurrent.TimeUnit;
@@ -717,34 +724,47 @@ public class MtgLifeFragmentTest {
                         assertNotNull(timerContainer);
                         assertEquals(View.GONE, timerContainer.getVisibility());
                     });
+        }
+    }
+
     @Test
+    @SuppressWarnings("RestrictedApi")
     public void testChooserMenuItemNavigatesToChooser() {
-        try (androidx.test.core.app.ActivityScenario<com.nicue.onetwo.MainActivity> scenario =
-                androidx.test.core.app.ActivityScenario.launch(com.nicue.onetwo.MainActivity.class)) {
+        try (ActivityScenario<MainActivity> scenario =
+                ActivityScenario.launch(MainActivity.class)) {
             scenario.onActivity(
                     activity -> {
-                        androidx.fragment.app.Fragment fragment =
+                        Fragment fragment =
                                 activity.getSupportFragmentManager()
                                         .findFragmentById(R.id.nav_host_fragment);
                         assertNotNull(fragment);
-                        androidx.navigation.NavController navController =
-                                ((androidx.navigation.fragment.NavHostFragment) fragment).getNavController();
+                        NavController navController =
+                                ((NavHostFragment) fragment).getNavController();
 
                         // Currently at start destination (nav_mtg_life)
-                        assertEquals(R.id.nav_mtg_life, navController.getCurrentDestination().getId());
+                        assertEquals(
+                                R.id.nav_mtg_life, navController.getCurrentDestination().getId());
 
-                        // Find the visible Fragment
-                        androidx.fragment.app.Fragment currentFragment = fragment.getChildFragmentManager().getFragments().get(0);
+                        Fragment currentFragment =
+                                fragment.getChildFragmentManager().getFragments().get(0);
                         assertTrue(currentFragment instanceof MtgLifeFragment);
                         MtgLifeFragment mtgLifeFragment = (MtgLifeFragment) currentFragment;
 
-                        // Click the chooser menu item
-                        org.robolectric.fakes.RoboMenuItem chooserMenuItem =
-                                new org.robolectric.fakes.RoboMenuItem(R.id.action_chooser);
+                        View view = mtgLifeFragment.requireView();
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertNotNull(setupContent);
+                        assertEquals(View.GONE, setupContent.getVisibility());
+
+                        MenuBuilder menu = new MenuBuilder(activity);
+                        mtgLifeFragment.onCreateMenu(menu, activity.getMenuInflater());
+                        MenuItem chooserMenuItem = menu.findItem(R.id.action_chooser);
+                        assertNotNull(chooserMenuItem);
+                        assertTrue(chooserMenuItem.isVisible());
+
                         mtgLifeFragment.onMenuItemSelected(chooserMenuItem);
 
-                        // Assert we navigated to nav_chooser
-                        assertEquals(R.id.nav_chooser, navController.getCurrentDestination().getId());
+                        assertEquals(
+                                R.id.nav_chooser, navController.getCurrentDestination().getId());
                     });
         }
     }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -769,6 +769,52 @@ public class MtgLifeFragmentTest {
         }
     }
 
+    @Test
+    public void testChooseAndStartButtonNavigatesToChooser() {
+        try (ActivityScenario<MainActivity> scenario =
+                ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(
+                    activity -> {
+                        Fragment fragment =
+                                activity.getSupportFragmentManager()
+                                        .findFragmentById(R.id.nav_host_fragment);
+                        assertNotNull(fragment);
+                        NavController navController =
+                                ((NavHostFragment) fragment).getNavController();
+
+                        // Navigate to setup content first
+                        Fragment currentFragment =
+                                fragment.getChildFragmentManager().getFragments().get(0);
+                        assertTrue(currentFragment instanceof MtgLifeFragment);
+                        MtgLifeFragment mtgLifeFragment = (MtgLifeFragment) currentFragment;
+
+                        org.robolectric.fakes.RoboMenuItem newGameItem =
+                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+                        mtgLifeFragment.onMenuItemSelected(newGameItem);
+
+                        View view = mtgLifeFragment.requireView();
+                        View setupContent = view.findViewById(R.id.setup_content);
+                        assertNotNull(setupContent);
+                        assertEquals(View.VISIBLE, setupContent.getVisibility());
+
+                        // Fill details
+                        EditText playersInput = view.findViewById(R.id.players_input);
+                        EditText lifeInput = view.findViewById(R.id.life_input);
+                        playersInput.setText("4");
+                        lifeInput.setText("40");
+
+                        // Press Choose 1st & Start button
+                        Button chooseAndStartButton = view.findViewById(R.id.choose_and_start_button);
+                        assertNotNull(chooseAndStartButton);
+                        chooseAndStartButton.performClick();
+
+                        // Assert we navigated to nav_chooser
+                        assertEquals(
+                                R.id.nav_chooser, navController.getCurrentDestination().getId());
+                    });
+        }
+    }
+
     private static View findViewWithContentDescription(View root, CharSequence contentDescription) {
         if (root == null) {
             return null;

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -628,6 +628,16 @@ public class MtgLifeViewModelTest {
     }
 
     @Test
+    public void testStartingPlayerUpdatesTurnTimerActiveSeat() {
+        viewModel.validateAndStartGame("4", "40", true, true);
+        assertEquals(0, viewModel.getTurnTimerActiveSeatIndex());
+
+        viewModel.setStartingPlayer(2);
+        assertEquals(Integer.valueOf(2), viewModel.getStartingPlayer());
+        assertEquals(2, viewModel.getTurnTimerActiveSeatIndex());
+    }
+
+    @Test
     public void testStartingPlayerFromIntentExtraInteger() {
         SavedStateHandle handle = new SavedStateHandle();
         handle.set("starting_player", 1);

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -658,4 +658,26 @@ public class MtgLifeViewModelTest {
         MtgLifeViewModel vm = new MtgLifeViewModel(handle, nowProvider);
         assertNull(vm.getStartingPlayer());
     }
+
+    @Test
+    public void testStartTimerVisibilityFlow() throws Exception {
+        FakeTimerScheduler fakeScheduler = new FakeTimerScheduler(nowProvider);
+        viewModel = new MtgLifeViewModel(new SavedStateHandle(), nowProvider, fakeScheduler);
+        viewModel.setTurnTimerDurationMs(180000L);
+        viewModel.validateAndStartGame("2", "40", true, true);
+
+        // Before starting: active player (0) should have start button visible, inactive player (1) should not
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.getPlayers().get(0).isStartTimerVisible());
+        assertFalse(state.getPlayers().get(1).isStartTimerVisible());
+
+        // Start the timer
+        viewModel.startTimer();
+
+        // After starting: active player's start button should be gone
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.getPlayers().get(0).isStartTimerVisible());
+        assertFalse(state.getPlayers().get(1).isStartTimerVisible());
+        assertFalse(state.isTurnTimerPaused());
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -617,4 +617,45 @@ public class MtgLifeViewModelTest {
         assertFalse(viewModel.validateAndStartGame("4", "0"));
         assertFalse(viewModel.validateAndStartGame("abc", "xyz"));
     }
+
+    @Test
+    public void testStartingPlayerProgrammatic() {
+        assertNull(viewModel.getStartingPlayer());
+        viewModel.setStartingPlayer(2);
+        assertEquals(Integer.valueOf(2), viewModel.getStartingPlayer());
+        viewModel.setStartingPlayer(null);
+        assertNull(viewModel.getStartingPlayer());
+    }
+
+    @Test
+    public void testStartingPlayerFromIntentExtraInteger() {
+        SavedStateHandle handle = new SavedStateHandle();
+        handle.set("starting_player", 1);
+        MtgLifeViewModel vm = new MtgLifeViewModel(handle, nowProvider);
+        assertEquals(Integer.valueOf(1), vm.getStartingPlayer());
+    }
+
+    @Test
+    public void testStartingPlayerFromIntentExtraString() {
+        SavedStateHandle handle = new SavedStateHandle();
+        handle.set("starting_player", "3");
+        MtgLifeViewModel vm = new MtgLifeViewModel(handle, nowProvider);
+        assertEquals(Integer.valueOf(3), vm.getStartingPlayer());
+    }
+
+    @Test
+    public void testStartingPlayerFromIntentExtraCamelCase() {
+        SavedStateHandle handle = new SavedStateHandle();
+        handle.set("startingPlayer", 4);
+        MtgLifeViewModel vm = new MtgLifeViewModel(handle, nowProvider);
+        assertEquals(Integer.valueOf(4), vm.getStartingPlayer());
+    }
+
+    @Test
+    public void testStartingPlayerFromIntentExtraInvalid() {
+        SavedStateHandle handle = new SavedStateHandle();
+        handle.set("starting_player", "not_an_int");
+        MtgLifeViewModel vm = new MtgLifeViewModel(handle, nowProvider);
+        assertNull(vm.getStartingPlayer());
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -609,4 +609,12 @@ public class MtgLifeViewModelTest {
         // Player 0 should not have been charged (displaying "5:00").
         assertEquals("5:00", player0.getTimerDisplay());
     }
+
+    @Test
+    public void testValidateAndStartGameReturnsCorrectBoolean() {
+        assertTrue(viewModel.validateAndStartGame("4", "40"));
+        assertFalse(viewModel.validateAndStartGame("0", "40"));
+        assertFalse(viewModel.validateAndStartGame("4", "0"));
+        assertFalse(viewModel.validateAndStartGame("abc", "xyz"));
+    }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -676,7 +676,8 @@ public class MtgLifeViewModelTest {
         viewModel.setTurnTimerDurationMs(180000L);
         viewModel.validateAndStartGame("2", "40", true, true);
 
-        // Before starting: active player (0) should have start button visible, inactive player (1) should not
+        // Before starting: active player (0) should have start button visible, inactive player (1)
+        // should not
         MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
         assertTrue(state.getPlayers().get(0).isStartTimerVisible());
         assertFalse(state.getPlayers().get(1).isStartTimerVisible());

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeViewModelTest.java
@@ -680,4 +680,25 @@ public class MtgLifeViewModelTest {
         assertFalse(state.getPlayers().get(1).isStartTimerVisible());
         assertFalse(state.isTurnTimerPaused());
     }
+
+    @Test
+    public void testTogglePlayPause() throws Exception {
+        FakeTimerScheduler fakeScheduler = new FakeTimerScheduler(nowProvider);
+        viewModel = new MtgLifeViewModel(new SavedStateHandle(), nowProvider, fakeScheduler);
+        viewModel.setTurnTimerDurationMs(180000L);
+        viewModel.validateAndStartGame("2", "40", true, true);
+
+        MtgLifeUiState state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isTurnTimerPaused());
+
+        // Toggle to play (start)
+        viewModel.togglePlayPause();
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertFalse(state.isTurnTimerPaused());
+
+        // Toggle to pause
+        viewModel.togglePlayPause();
+        state = LiveDataTestUtil.getValue(viewModel.getUiState());
+        assertTrue(state.isTurnTimerPaused());
+    }
 }


### PR DESCRIPTION
This was implemented via intents
- Users can now choose and then go back to the MtgLifeCounter fragment
- Users can now get an estimate of starting player that gets sent back via the intent
- Users can now play and pause clock with a long click