### PR TITLE
Add corner accent indicators to MTG life counter cells

### DIFF
--- a/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/LifePlayerUiModel.java
@@ -8,6 +8,7 @@ public class LifePlayerUiModel {
     private final int rotationDegrees;
     private final int backgroundColorRes;
     private final int foregroundColorRes;
+    private final int accentBackgroundColorRes;
     private final int recentLifeChange;
     private final long recentLifeChangeTimestampMs;
     private final boolean commanderDamageVisible;
@@ -25,6 +26,7 @@ public class LifePlayerUiModel {
             int rotationDegrees,
             int backgroundColorRes,
             int foregroundColorRes,
+            int accentBackgroundColorRes,
             int recentLifeChange,
             long recentLifeChangeTimestampMs,
             boolean commanderDamageVisible,
@@ -40,6 +42,7 @@ public class LifePlayerUiModel {
         this.rotationDegrees = rotationDegrees;
         this.backgroundColorRes = backgroundColorRes;
         this.foregroundColorRes = foregroundColorRes;
+        this.accentBackgroundColorRes = accentBackgroundColorRes;
         this.recentLifeChange = recentLifeChange;
         this.recentLifeChangeTimestampMs = recentLifeChangeTimestampMs;
         this.commanderDamageVisible = commanderDamageVisible;
@@ -70,6 +73,10 @@ public class LifePlayerUiModel {
 
     public int getForegroundColorRes() {
         return foregroundColorRes;
+    }
+
+    public int getAccentBackgroundColorRes() {
+        return accentBackgroundColorRes;
     }
 
     public int getRecentLifeChange() {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -353,7 +353,18 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                 player.isTimerExpired()
                         ? ContextCompat.getColor(requireContext(), R.color.mtg_expired_foreground)
                         : ContextCompat.getColor(requireContext(), player.getForegroundColorRes());
+        int accentBgColor =
+                player.isTimerExpired()
+                        ? ContextCompat.getColor(requireContext(), R.color.mtg_expired_foreground)
+                        : ContextCompat.getColor(
+                                requireContext(), player.getAccentBackgroundColorRes());
         int seatIndex = player.getSeatIndex();
+
+        ColorStateList accentTint = ColorStateList.valueOf(accentBgColor);
+        cellBinding.playerColorIndicatorStart.setImageTintList(accentTint);
+        cellBinding.playerColorIndicatorEnd.setImageTintList(accentTint);
+        cellBinding.playerColorIndicatorBottomStart.setImageTintList(accentTint);
+        cellBinding.playerColorIndicatorBottomEnd.setImageTintList(accentTint);
 
         TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
                 cellBinding.tvLifeCount,

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeViewModel.java
@@ -781,6 +781,7 @@ public class MtgLifeViewModel extends ViewModel {
                                 getRotationForSeat(seatIndex, totalPlayers),
                                 getBackgroundColorResForSeat(seatIndex),
                                 getForegroundColorResForSeat(seatIndex),
+                                getAccentBackgroundColorResForSeat(seatIndex),
                                 recentLifeChange,
                                 recentLifeChangeTimestampMs,
                                 commanderDamageEnabled && totalPlayers > 1,

--- a/app/src/main/res/drawable/ic_corner_bracket.xml
+++ b/app/src/main/res/drawable/ic_corner_bracket.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 4,24 L 4,4 L 24,4" />
+</vector>

--- a/app/src/main/res/layout/life_player_cell.xml
+++ b/app/src/main/res/layout/life_player_cell.xml
@@ -5,6 +5,46 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ImageView
+        android:id="@+id/player_color_indicator_start"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_margin="0dp"
+        android:src="@drawable/ic_corner_bracket"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/player_color_indicator_end"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_margin="0dp"
+        android:src="@drawable/ic_corner_bracket"
+        android:scaleX="-1"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <ImageView
+        android:id="@+id/player_color_indicator_bottom_start"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_margin="0dp"
+        android:src="@drawable/ic_corner_bracket"
+        android:scaleY="-1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/player_color_indicator_bottom_end"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_margin="0dp"
+        android:src="@drawable/ic_corner_bracket"
+        android:scaleX="-1"
+        android:scaleY="-1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/inner_player_layout"
         android:layout_width="0dp"


### PR DESCRIPTION
## Summary
- Add a new accent color resource to `LifePlayerUiModel` and populate it from `MtgLifeViewModel`.
- Tint the four corner indicator drawables in `MtgLifeFragment` so each player cell gets a colored bracket accent.
- Add the `ic_corner_bracket` vector and place the indicators in `life_player_cell.xml`.

## Testing
- Not run (not requested)
- UI behavior was updated in the fragment and layout; recommend a quick emulator/device check to confirm the corner accents render correctly across player counts.