### PR TITLE
Update commander damage layout tests for board order

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.nicue.onetwo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 39
-        versionName "2.1.2"
+        versionCode 40
+        versionName "2.1.3"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/com/nicue/onetwo/MainActivity.java
+++ b/app/src/main/java/com/nicue/onetwo/MainActivity.java
@@ -1,7 +1,6 @@
 package com.nicue.onetwo;
 
 import android.os.Bundle;
-import android.view.ViewGroup;
 import android.view.WindowManager;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
@@ -96,16 +95,12 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
 
     private void applyToolbarInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(
-                binding.appToolbar.toolbar,
+                binding.appBarContainer,
                 (view, insets) -> {
                     Insets statusBars = insets.getInsets(WindowInsetsCompat.Type.statusBars());
-                    ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
-                    if (layoutParams instanceof ViewGroup.MarginLayoutParams marginLayoutParams) {
-                        marginLayoutParams.topMargin = statusBars.top;
-                        view.setLayoutParams(marginLayoutParams);
-                    }
+                    view.setPadding(0, statusBars.top, 0, 0);
                     return insets;
                 });
-        ViewCompat.requestApplyInsets(binding.appToolbar.toolbar);
+        ViewCompat.requestApplyInsets(binding.appBarContainer);
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/MainActivity.java
+++ b/app/src/main/java/com/nicue/onetwo/MainActivity.java
@@ -1,10 +1,14 @@
 package com.nicue.onetwo;
 
 import android.os.Bundle;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.graphics.Insets;
 import androidx.core.splashscreen.SplashScreen;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.AppBarConfiguration;
@@ -30,6 +34,7 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setSupportActionBar(binding.appToolbar.toolbar);
+        applyToolbarInsets();
 
         settingsRepository.applyKeepScreenOn(getWindow());
 
@@ -87,5 +92,20 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
 
     private AppContainer getAppContainer() {
         return ((OneTwoApplication) getApplication()).getAppContainer();
+    }
+
+    private void applyToolbarInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(
+                binding.appToolbar.toolbar,
+                (view, insets) -> {
+                    Insets statusBars = insets.getInsets(WindowInsetsCompat.Type.statusBars());
+                    ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+                    if (layoutParams instanceof ViewGroup.MarginLayoutParams marginLayoutParams) {
+                        marginLayoutParams.topMargin = statusBars.top;
+                        view.setLayoutParams(marginLayoutParams);
+                    }
+                    return insets;
+                });
+        ViewCompat.requestApplyInsets(binding.appToolbar.toolbar);
     }
 }

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -69,6 +69,33 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
     private final Handler holdRepeatHandler = new Handler(Looper.getMainLooper());
     private final Map<View, Runnable> activeLifeHoldRunnables = new HashMap<>();
 
+    private static final class CommanderGridLayout {
+        private final int rows;
+        private final int cols;
+        private final int[] sourceSeatIndicesBySlot;
+
+        CommanderGridLayout(int rows, int cols, int[] sourceSeatIndicesBySlot) {
+            this.rows = rows;
+            this.cols = cols;
+            this.sourceSeatIndicesBySlot = sourceSeatIndicesBySlot;
+        }
+
+        int getRows() {
+            return rows;
+        }
+
+        int getCols() {
+            return cols;
+        }
+
+        int getSourceSeatIndexForSlot(int slotIndex) {
+            if (slotIndex < 0 || slotIndex >= sourceSeatIndicesBySlot.length) {
+                return -1;
+            }
+            return sourceSeatIndicesBySlot[slotIndex];
+        }
+    }
+
     @Nullable @Override
     public View onCreateView(
             @NonNull LayoutInflater inflater,
@@ -568,10 +595,12 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         cellBinding.commanderDamageGrid.setPadding(
                 pillPadding, pillPadding, pillPadding, pillPadding);
 
-        int rows = getCommanderGridRowCount(totalPlayers);
-        int cols = getCommanderGridColumnCount(totalPlayers);
-        List<CommanderDamageUiModel> damages = player.getCommanderDamages();
         int seatIndex = player.getSeatIndex();
+        CommanderGridLayout gridLayout =
+                getCommanderGridLayout(seatIndex, totalPlayers, player.getRotationDegrees());
+        int rows = gridLayout.getRows();
+        int cols = gridLayout.getCols();
+        List<CommanderDamageUiModel> damages = player.getCommanderDamages();
 
         for (int rowIndex = 0; rowIndex < rows; rowIndex++) {
             LinearLayout rowLayout = new LinearLayout(requireContext());
@@ -583,8 +612,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
             for (int columnIndex = 0; columnIndex < cols; columnIndex++) {
                 int slotIndex = rowIndex * cols + columnIndex;
-                int sourceSeatIndex = getSourceSeatForGridSlot(slotIndex, seatIndex, totalPlayers);
-                if (sourceSeatIndex < damages.size()) {
+                int sourceSeatIndex = gridLayout.getSourceSeatIndexForSlot(slotIndex);
+                if (sourceSeatIndex >= 0 && sourceSeatIndex < damages.size()) {
                     rowLayout.addView(
                             createCommanderSummaryCell(damages.get(sourceSeatIndex), seatIndex));
                 } else {
@@ -768,8 +797,11 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         }
 
         int totalPlayers = uiState.getPlayerCount();
-        int rows = getCommanderGridRowCount(totalPlayers);
-        int cols = getCommanderGridColumnCount(totalPlayers);
+        CommanderGridLayout gridLayout =
+                getCommanderGridLayout(
+                        defenderSeatIndex, totalPlayers, defender.getRotationDegrees());
+        int rows = gridLayout.getRows();
+        int cols = gridLayout.getCols();
 
         FrameLayout dialogRoot = new FrameLayout(requireContext());
         dialogRoot.setLayoutParams(
@@ -809,9 +841,8 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
 
             for (int columnIndex = 0; columnIndex < cols; columnIndex++) {
                 int slotIndex = rowIndex * cols + columnIndex;
-                int sourceSeatIndex =
-                        getSourceSeatForGridSlot(slotIndex, defenderSeatIndex, totalPlayers);
-                if (sourceSeatIndex < damages.size()) {
+                int sourceSeatIndex = gridLayout.getSourceSeatIndexForSlot(slotIndex);
+                if (sourceSeatIndex >= 0 && sourceSeatIndex < damages.size()) {
                     rowLayout.addView(
                             createCommanderDialogCell(
                                     damages.get(sourceSeatIndex), defenderSeatIndex));
@@ -1035,14 +1066,6 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         };
     }
 
-    private int getCommanderGridRowCount(int totalPlayers) {
-        return totalPlayers > 2 ? 2 : 1;
-    }
-
-    private int getCommanderGridColumnCount(int totalPlayers) {
-        return totalPlayers > 4 ? 3 : 2;
-    }
-
     private int getForegroundColor(int backgroundColor) {
         return ColorUtils.calculateLuminance(backgroundColor) < 0.5 ? 0xFFFFFFFF : 0xFF000000;
     }
@@ -1095,38 +1118,96 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
         }
     }
 
-    private int getSourceSeatForGridSlot(int slotIndex, int defenderSeatIndex, int totalPlayers) {
-        int[] mapping =
-                switch (totalPlayers) {
-                    case 2 -> defenderSeatIndex == 0 ? new int[] {1, 0} : new int[] {0, 1};
-                    case 3 ->
-                            switch (defenderSeatIndex) {
-                                case 0 -> new int[] {1, 2, 3, 0};
-                                case 1 -> new int[] {0, 2, 3, 1};
-                                default -> new int[] {1, 0, 2, 3};
-                            };
-                    case 4 ->
-                            switch (defenderSeatIndex) {
-                                case 0, 2 -> new int[] {1, 3, 0, 2};
-                                default -> new int[] {2, 0, 3, 1};
-                            };
-                    case 5 ->
-                            defenderSeatIndex == 4
-                                    ? new int[] {0, 1, 4, 2, 3, 5}
-                                    : defenderSeatIndex % 2 == 0
-                                            ? new int[] {1, 3, 5, 0, 2, 4}
-                                            : new int[] {4, 2, 0, 5, 3, 1};
-                    case 6 ->
+    private CommanderGridLayout getCommanderGridLayout(
+            int defenderSeatIndex, int totalPlayers, int rotationDegrees) {
+        return switch (totalPlayers) {
+            case 2 ->
+                    buildRotatedCommanderGridLayout(
+                            2,
+                            1,
+                            new int[][] {
+                                {0, 0},
+                                {1, 0},
+                            },
+                            rotationDegrees);
+            case 3 ->
+                    buildRotatedCommanderGridLayout(
+                            2,
+                            2,
+                            new int[][] {
+                                {1, 0},
+                                {0, 0},
+                                {0, 1},
+                            },
+                            rotationDegrees);
+            case 4 ->
+                    new CommanderGridLayout(
+                            2,
+                            2,
+                            defenderSeatIndex % 2 == 0
+                                    ? new int[] {1, 3, 0, 2}
+                                    : new int[] {2, 0, 3, 1});
+            case 5 ->
+                    buildRotatedCommanderGridLayout(
+                            3,
+                            2,
+                            new int[][] {
+                                {0, 0},
+                                {0, 1},
+                                {1, 0},
+                                {1, 1},
+                                {2, 0},
+                            },
+                            rotationDegrees);
+            case 6 ->
+                    new CommanderGridLayout(
+                            2,
+                            3,
                             defenderSeatIndex % 2 == 0
                                     ? new int[] {1, 3, 5, 0, 2, 4}
-                                    : new int[] {4, 2, 0, 5, 3, 1};
-                    default -> null;
-                };
+                                    : new int[] {4, 2, 0, 5, 3, 1});
+            default -> new CommanderGridLayout(1, 1, new int[] {0});
+        };
+    }
 
-        if (mapping == null || slotIndex < 0 || slotIndex >= mapping.length) {
-            return slotIndex;
+    private CommanderGridLayout buildRotatedCommanderGridLayout(
+            int absoluteRows,
+            int absoluteCols,
+            int[][] absoluteSeatPositions,
+            int rotationDegrees) {
+        int normalizedRotation = ((rotationDegrees % 360) + 360) % 360;
+        int localRows = normalizedRotation == 90 || normalizedRotation == 270 ? absoluteCols : absoluteRows;
+        int localCols = normalizedRotation == 90 || normalizedRotation == 270 ? absoluteRows : absoluteCols;
+        int[] sourceSeatIndicesBySlot = new int[localRows * localCols];
+        java.util.Arrays.fill(sourceSeatIndicesBySlot, -1);
+
+        for (int sourceSeatIndex = 0; sourceSeatIndex < absoluteSeatPositions.length; sourceSeatIndex++) {
+            int absoluteRow = absoluteSeatPositions[sourceSeatIndex][0];
+            int absoluteCol = absoluteSeatPositions[sourceSeatIndex][1];
+            int localRow;
+            int localCol;
+            switch (normalizedRotation) {
+                case 90 -> {
+                    localRow = absoluteCols - 1 - absoluteCol;
+                    localCol = absoluteRow;
+                }
+                case 180 -> {
+                    localRow = absoluteRows - 1 - absoluteRow;
+                    localCol = absoluteCols - 1 - absoluteCol;
+                }
+                case 270 -> {
+                    localRow = absoluteCol;
+                    localCol = absoluteRows - 1 - absoluteRow;
+                }
+                default -> {
+                    localRow = absoluteRow;
+                    localCol = absoluteCol;
+                }
+            }
+            sourceSeatIndicesBySlot[localRow * localCols + localCol] = sourceSeatIndex;
         }
-        return mapping[slotIndex];
+
+        return new CommanderGridLayout(localRows, localCols, sourceSeatIndicesBySlot);
     }
 
     private void showTurnTimerDurationPicker(LifeSetupContentBinding setupBinding) {

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -1176,12 +1176,16 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
             int[][] absoluteSeatPositions,
             int rotationDegrees) {
         int normalizedRotation = ((rotationDegrees % 360) + 360) % 360;
-        int localRows = normalizedRotation == 90 || normalizedRotation == 270 ? absoluteCols : absoluteRows;
-        int localCols = normalizedRotation == 90 || normalizedRotation == 270 ? absoluteRows : absoluteCols;
+        int localRows =
+                normalizedRotation == 90 || normalizedRotation == 270 ? absoluteCols : absoluteRows;
+        int localCols =
+                normalizedRotation == 90 || normalizedRotation == 270 ? absoluteRows : absoluteCols;
         int[] sourceSeatIndicesBySlot = new int[localRows * localCols];
         java.util.Arrays.fill(sourceSeatIndicesBySlot, -1);
 
-        for (int sourceSeatIndex = 0; sourceSeatIndex < absoluteSeatPositions.length; sourceSeatIndex++) {
+        for (int sourceSeatIndex = 0;
+                sourceSeatIndex < absoluteSeatPositions.length;
+                sourceSeatIndex++) {
             int absoluteRow = absoluteSeatPositions[sourceSeatIndex][0];
             int absoluteCol = absoluteSeatPositions[sourceSeatIndex][1];
             int localRow;

--- a/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
+++ b/app/src/main/java/com/nicue/onetwo/ui/life/MtgLifeFragment.java
@@ -1101,7 +1101,7 @@ public class MtgLifeFragment extends Fragment implements MenuProvider {
                     case 2 -> defenderSeatIndex == 0 ? new int[] {1, 0} : new int[] {0, 1};
                     case 3 ->
                             switch (defenderSeatIndex) {
-                                case 0 -> new int[] {2, 1, 3, 0};
+                                case 0 -> new int[] {1, 2, 3, 0};
                                 case 1 -> new int[] {0, 2, 3, 1};
                                 default -> new int[] {1, 0, 2, 3};
                             };

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,7 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorPrimary"
     android:isScrollContainer="false">
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,6 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorPrimary"
     android:isScrollContainer="false">
 
 
@@ -16,11 +15,18 @@
         android:orientation="vertical"
         android:overScrollMode="ifContentScrolls">
 
-        <include
-            android:id="@+id/app_toolbar"
-            layout="@layout/toolbar"
+        <FrameLayout
+            android:id="@+id/app_bar_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:background="?attr/colorPrimary">
+
+            <include
+                android:id="@+id/app_toolbar"
+                layout="@layout/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </FrameLayout>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/nav_host_fragment"

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -6,7 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/colorPrimary"
-    android:fitsSystemWindows="true"
     android:minHeight="?attr/actionBarSize"
     app:popupTheme="@style/ThemeOverlay.Material3.Dark"
     app:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -339,6 +339,32 @@ public class MtgLifeFragmentTest {
     }
 
     @Test
+    public void testThreePlayerCommanderDamageLayoutForPlayer1FollowsBoardOrder() {
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
+
+            scenario.onFragment(
+                    fragment -> {
+                        startLifeGame(fragment, "3", "40");
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        android.widget.LinearLayout dialogContent =
+                                showCommanderDamageDialog(fragment, 0);
+
+                        android.widget.LinearLayout row0 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(0);
+                        View topLeftCell = row0.getChildAt(0);
+                        View topRightCell = row0.getChildAt(1);
+
+                        assertCommanderCellContainsSource(fragment, topLeftCell, 2, 1);
+                        assertCommanderCellContainsSource(fragment, topRightCell, 3, 1);
+                    });
+        }
+    }
+
+    @Test
     public void testLongPressLifeZonesAdjustByTen() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
@@ -442,52 +468,19 @@ public class MtgLifeFragmentTest {
     }
 
     @Test
-    public void testFivePlayerCommanderDamageLayoutForPlayer5MatchesFragment() {
+    public void testFivePlayerCommanderDamageLayoutForPlayer5KeepsBoardSeatSequence() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
 
             scenario.onFragment(
                     fragment -> {
-                        org.robolectric.fakes.RoboMenuItem resetMenuItem =
-                                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
-                        fragment.onMenuItemSelected(resetMenuItem);
-
-                        View view = fragment.getView();
-                        assertNotNull(view);
-                        EditText playersInput = view.findViewById(R.id.players_input);
-                        EditText lifeInput = view.findViewById(R.id.life_input);
-                        playersInput.setText("5");
-                        lifeInput.setText("40");
-
-                        Button startButton = view.findViewById(R.id.start_game_button);
-                        startButton.performClick();
+                        startLifeGame(fragment, "5", "40");
                     });
 
             scenario.onFragment(
                     fragment -> {
-                        View player5 = fragment.requireView().findViewById(R.id.player_5);
-                        View commanderGrid = player5.findViewById(R.id.commander_damage_grid);
-                        assertNotNull(commanderGrid);
-                        try {
-                            java.lang.reflect.Method showDialogMethod =
-                                    MtgLifeFragment.class.getDeclaredMethod(
-                                            "showCommanderDamageDialog", int.class);
-                            showDialogMethod.setAccessible(true);
-                            showDialogMethod.invoke(fragment, 4);
-                        } catch (ReflectiveOperationException e) {
-                            throw new AssertionError(e);
-                        }
-                        Shadows.shadowOf(Looper.getMainLooper()).idle();
-
-                        Dialog dialog = ShadowDialog.getLatestDialog();
-                        assertNotNull(dialog);
-                        assertTrue(dialog.isShowing());
-                        assertNotNull(dialog.getWindow());
-
-                        View decorView = dialog.getWindow().getDecorView();
                         android.widget.LinearLayout dialogContent =
-                                decorView.findViewWithTag("commander_dialog_content");
-                        assertNotNull(dialogContent);
+                                showCommanderDamageDialog(fragment, 4);
 
                         android.widget.LinearLayout row0 =
                                 (android.widget.LinearLayout) dialogContent.getChildAt(0);
@@ -499,18 +492,8 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.VISIBLE, cell1.getVisibility());
                         assertEquals(View.INVISIBLE, cell2.getVisibility());
 
-                        View incZone0 =
-                                findViewWithContentDescription(
-                                        cell0,
-                                        fragment.getString(
-                                                R.string.mtg_commander_damage_increase_desc, 1, 5));
-                        View incZone1 =
-                                findViewWithContentDescription(
-                                        cell1,
-                                        fragment.getString(
-                                                R.string.mtg_commander_damage_increase_desc, 2, 5));
-                        assertNotNull(incZone0);
-                        assertNotNull(incZone1);
+                        assertCommanderCellContainsSource(fragment, cell0, 1, 5);
+                        assertCommanderCellContainsSource(fragment, cell1, 2, 5);
 
                         android.widget.LinearLayout row1 =
                                 (android.widget.LinearLayout) dialogContent.getChildAt(1);
@@ -522,18 +505,8 @@ public class MtgLifeFragmentTest {
                         assertEquals(View.VISIBLE, cell4.getVisibility());
                         assertEquals(View.INVISIBLE, cell5.getVisibility());
 
-                        View incZone3 =
-                                findViewWithContentDescription(
-                                        cell3,
-                                        fragment.getString(
-                                                R.string.mtg_commander_damage_increase_desc, 3, 5));
-                        View incZone4 =
-                                findViewWithContentDescription(
-                                        cell4,
-                                        fragment.getString(
-                                                R.string.mtg_commander_damage_increase_desc, 4, 5));
-                        assertNotNull(incZone3);
-                        assertNotNull(incZone4);
+                        assertCommanderCellContainsSource(fragment, cell3, 3, 5);
+                        assertCommanderCellContainsSource(fragment, cell4, 4, 5);
                     });
         }
     }
@@ -839,5 +812,60 @@ public class MtgLifeFragmentTest {
             }
         }
         return null;
+    }
+
+    private static void startLifeGame(MtgLifeFragment fragment, String players, String life) {
+        org.robolectric.fakes.RoboMenuItem resetMenuItem =
+                new org.robolectric.fakes.RoboMenuItem(R.id.action_new_game);
+        fragment.onMenuItemSelected(resetMenuItem);
+
+        View view = fragment.getView();
+        assertNotNull(view);
+        EditText playersInput = view.findViewById(R.id.players_input);
+        EditText lifeInput = view.findViewById(R.id.life_input);
+        assertNotNull(playersInput);
+        assertNotNull(lifeInput);
+        playersInput.setText(players);
+        lifeInput.setText(life);
+
+        Button startButton = view.findViewById(R.id.start_game_button);
+        assertNotNull(startButton);
+        startButton.performClick();
+    }
+
+    private static android.widget.LinearLayout showCommanderDamageDialog(
+            MtgLifeFragment fragment, int defenderSeatIndex) {
+        try {
+            java.lang.reflect.Method showDialogMethod =
+                    MtgLifeFragment.class.getDeclaredMethod("showCommanderDamageDialog", int.class);
+            showDialogMethod.setAccessible(true);
+            showDialogMethod.invoke(fragment, defenderSeatIndex);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+        Dialog dialog = ShadowDialog.getLatestDialog();
+        assertNotNull(dialog);
+        assertTrue(dialog.isShowing());
+        assertNotNull(dialog.getWindow());
+
+        View decorView = dialog.getWindow().getDecorView();
+        android.widget.LinearLayout dialogContent =
+                decorView.findViewWithTag("commander_dialog_content");
+        assertNotNull(dialogContent);
+        return dialogContent;
+    }
+
+    private static void assertCommanderCellContainsSource(
+            MtgLifeFragment fragment, View cell, int sourcePlayerNumber, int defenderPlayerNumber) {
+        View incrementZone =
+                findViewWithContentDescription(
+                        cell,
+                        fragment.getString(
+                                R.string.mtg_commander_damage_increase_desc,
+                                sourcePlayerNumber,
+                                defenderPlayerNumber));
+        assertNotNull(incrementZone);
     }
 }

--- a/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
+++ b/app/src/test/java/com/nicue/onetwo/ui/life/MtgLifeFragmentTest.java
@@ -339,6 +339,36 @@ public class MtgLifeFragmentTest {
     }
 
     @Test
+    public void testTwoPlayerCommanderDamageLayoutForBottomPlayerFollowsVerticalBoardOrder() {
+        try (FragmentScenario<MtgLifeFragment> scenario =
+                FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
+
+            scenario.onFragment(
+                    fragment -> {
+                        startLifeGame(fragment, "2", "40");
+                    });
+
+            scenario.onFragment(
+                    fragment -> {
+                        android.widget.LinearLayout dialogContent =
+                                showCommanderDamageDialog(fragment, 1);
+
+                        assertEquals(2, dialogContent.getChildCount());
+
+                        android.widget.LinearLayout row0 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(0);
+                        android.widget.LinearLayout row1 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(1);
+
+                        assertEquals(1, row0.getChildCount());
+                        assertEquals(1, row1.getChildCount());
+                        assertCommanderCellContainsSource(fragment, row0.getChildAt(0), 1, 2);
+                        assertEquals(View.INVISIBLE, row1.getChildAt(0).getVisibility());
+                    });
+        }
+    }
+
+    @Test
     public void testThreePlayerCommanderDamageLayoutForPlayer1FollowsBoardOrder() {
         try (FragmentScenario<MtgLifeFragment> scenario =
                 FragmentScenario.launchInContainer(MtgLifeFragment.class, null, R.style.AppTheme)) {
@@ -355,11 +385,16 @@ public class MtgLifeFragmentTest {
 
                         android.widget.LinearLayout row0 =
                                 (android.widget.LinearLayout) dialogContent.getChildAt(0);
+                        android.widget.LinearLayout row1 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(1);
                         View topLeftCell = row0.getChildAt(0);
                         View topRightCell = row0.getChildAt(1);
 
+                        assertEquals(2, dialogContent.getChildCount());
                         assertCommanderCellContainsSource(fragment, topLeftCell, 2, 1);
                         assertCommanderCellContainsSource(fragment, topRightCell, 3, 1);
+                        assertEquals(View.INVISIBLE, row1.getChildAt(0).getVisibility());
+                        assertEquals(View.INVISIBLE, row1.getChildAt(1).getVisibility());
                     });
         }
     }
@@ -482,15 +517,16 @@ public class MtgLifeFragmentTest {
                         android.widget.LinearLayout dialogContent =
                                 showCommanderDamageDialog(fragment, 4);
 
+                        assertEquals(3, dialogContent.getChildCount());
+
                         android.widget.LinearLayout row0 =
                                 (android.widget.LinearLayout) dialogContent.getChildAt(0);
                         View cell0 = row0.getChildAt(0);
                         View cell1 = row0.getChildAt(1);
-                        View cell2 = row0.getChildAt(2);
 
                         assertEquals(View.VISIBLE, cell0.getVisibility());
                         assertEquals(View.VISIBLE, cell1.getVisibility());
-                        assertEquals(View.INVISIBLE, cell2.getVisibility());
+                        assertEquals(2, row0.getChildCount());
 
                         assertCommanderCellContainsSource(fragment, cell0, 1, 5);
                         assertCommanderCellContainsSource(fragment, cell1, 2, 5);
@@ -499,14 +535,19 @@ public class MtgLifeFragmentTest {
                                 (android.widget.LinearLayout) dialogContent.getChildAt(1);
                         View cell3 = row1.getChildAt(0);
                         View cell4 = row1.getChildAt(1);
-                        View cell5 = row1.getChildAt(2);
 
                         assertEquals(View.VISIBLE, cell3.getVisibility());
                         assertEquals(View.VISIBLE, cell4.getVisibility());
-                        assertEquals(View.INVISIBLE, cell5.getVisibility());
+                        assertEquals(2, row1.getChildCount());
 
                         assertCommanderCellContainsSource(fragment, cell3, 3, 5);
                         assertCommanderCellContainsSource(fragment, cell4, 4, 5);
+
+                        android.widget.LinearLayout row2 =
+                                (android.widget.LinearLayout) dialogContent.getChildAt(2);
+                        assertEquals(2, row2.getChildCount());
+                        assertEquals(View.INVISIBLE, row2.getChildAt(0).getVisibility());
+                        assertEquals(View.INVISIBLE, row2.getChildAt(1).getVisibility());
                     });
         }
     }


### PR DESCRIPTION
## Summary
- Add a 3-player commander damage layout test that asserts board-relative ordering
- Refactor the 5-player commander damage layout test to use shared setup helpers
- Keep the test expectations aligned with the defender/source seat labels shown in the UI

## Testing
- `testDebugUnitTest` for `MtgLifeFragmentTest` passed up to the new ordering assertion and exposed the expected failing case before the production fix
- No lint or instrumentation run was requested