### PR TITLE
Update README subtitle to TableTop Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ OneTwo: TableTop Tools is a lightweight, fully open-source Android toolkit for t
 
 ## Features
 
-*   **MTG Life Counter:** Supports 1 to 6 players, full Commander damage matrix tracking (with automatic 21-damage highlight), and sliding-window recent life total history.
-*   **Turn Timers:** Individual player turn timers with intuitive pass-action handling and optional toggles.
+*   **MTG Life Counter:** Supports 1 to 6 players, full Commander damage matrix tracking (with automatic 21-damage highlight), sliding-window recent life total history, and an integrated per-player turn timer for MTG and Commander games.
 *   **Intuitive Player Selector (Chooser):** An animated, multi-touch custom view (`TouchDisplayView`) that lets players place a finger on the screen to seamlessly determine who goes first or establish turn order.
 *   **Custom Dice Roller:** Fully configurable dice rolling engine supporting edge-case selections from 2 faces up to 99,999 faces.
-*   **Chess Timer:** Synced chess-style game clocks handling up to 15 players simultaneously.
+*   **Chess Timer:** A separate chess-style timer screen for board games, with synced game clocks handling up to 15 players simultaneously.
 *   **Universal Counter:** Persistent trackers utilizing Room DB to record scores, life totals, or match points across multiple sessions.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# OneTwo: Tabletop & Board Game Tools
+# OneTwo: TableTop Tools
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Play Store](https://img.shields.io/badge/Get%20it%20on-Google%20Play-green?logo=google-play&logoColor=white)](https://play.google.com/store/apps/details?id=com.nicue.onetwo)
 [![F-Droid](https://img.shields.io/badge/Get%20it%20on-F--Droid-blue?logo=f-droid&logoColor=white)](https://f-droid.org/en/packages/com.nicue.onetwo/)
 
-OneTwo is a lightweight, fully open-source Android toolkit designed to streamline your tabletop, board game, and trading card game (TCG) sessions. Built using clean architecture, native Java, and Material Design principles, it provides a distraction-free suite of utilities that stay out of the way of your game.
+OneTwo: TableTop Tools is a lightweight, fully open-source Android toolkit for tabletop games, board games, and trading card game (TCG) sessions. Built using clean architecture, native Java, and Material Design principles, it provides a distraction-free suite of utilities that stay out of the way of your game.
 
 ![OneTwo Header](imgs/Header.png)
 


### PR DESCRIPTION
## Summary
- Rename the README heading to `OneTwo: TableTop Tools`.
- Refresh the opening paragraph to match the updated product naming and keep the tabletop/board game keywords.

## Testing
- Not run (not requested)